### PR TITLE
BPBROWSER-68: Added macOS multi-select

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
@@ -154,7 +154,7 @@ public class LocalFileTreeTablePresenter implements Initializable {
                     final List<String> rowNameList = new ArrayList<>();
                     row.setOnMouseClicked(event -> {
                         LOG.info("Mouse Clicked..");
-                        if (event.isControlDown() || event.isShiftDown()) {
+                        if (event.isControlDown() || event.isShiftDown() || event.isShortcutDown()) {
                             selectMultipleItems(rowNameList, row);
                         } else if (event.getClickCount() == 2) {
                             if (row.getTreeItem() != null && row.getTreeItem().getValue() != null && !row.getTreeItem().getValue().getType().equals(FileTreeModel.Type.File)) {


### PR DESCRIPTION
On MacOS multi-select of non-adjacent items is handled with '⌘' + Click
Java sees this as as a mouse click with shortcut down.