### PR TITLE
Only consume key press event for delete

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
@@ -190,15 +190,13 @@ public class Ds3TreeTablePresenter implements Initializable {
         ds3TreeTable.setContextMenu(contextMenu);
 
         ds3TreeTable.setOnKeyPressed(event -> {
-            LOG.info(event.getCode().getName() + " key pressed...");
             final ObservableList<TreeItem<Ds3TreeTableValue>> selectedItems = ds3TreeTable.getSelectionModel().getSelectedItems();
-
             if (!Guard.isNullOrEmpty(selectedItems)) {
                 if (event.getCode().equals(KeyCode.DELETE)) {
                     ds3Common.getDs3PanelPresenter().ds3DeleteObject(false);
+                    event.consume();
                 }
             }
-            event.consume();
         });
 
         ds3TreeTable.setRowFactory(view -> setTreeTableViewRowBehaviour());


### PR DESCRIPTION

The previous commit broke default behavior for certain keys such as up-arrow, down-arrow, control-a etc.