### PR TITLE
Update to 3.5 SDK; Fix for create new folder, which would create a Pu…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ subprojects {
     }
 
     dependencies {
-        compile 'com.spectralogic.ds3:ds3-sdk:3.4.0'
+        compile 'com.spectralogic.ds3:ds3-sdk:3.5.0'
         compile 'com.spectralogic.ds3:ds3-metadata:3.4.0'
         compile 'com.airhacks:afterburner.fx:1.7.0'
         compile 'org.controlsfx:controlsfx:8.40.12'

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createfolder/CreateFolderPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createfolder/CreateFolderPresenter.java
@@ -89,7 +89,7 @@ public class CreateFolderPresenter implements Initializable {
                     .getBucketName());
             //Instantiating create folder task
             final CreateFolderTask createFolderTask = new CreateFolderTask(createFolderModel.getClient(),
-                    createFolderModel, folderNameField.textProperty().getValue(),
+                    createFolderModel.getBucketName().trim(), folderNameField.textProperty().getValue().trim(),
                     PathUtil.getDs3ObjectList(location, folderNameField.textProperty().getValue()),
                     loggingService, resourceBundle);
             workers.execute(createFolderTask);

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/CreateFolderTask.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/CreateFolderTask.java
@@ -1,12 +1,15 @@
 package com.spectralogic.dsbrowser.gui.services.tasks;
 
 import com.spectralogic.ds3client.Ds3Client;
+import com.spectralogic.ds3client.commands.PutObjectRequest;
+import com.spectralogic.ds3client.commands.decorators.PutFolderRequest;
+import com.spectralogic.ds3client.commands.decorators.PutFolderResponse;
 import com.spectralogic.ds3client.commands.spectrads3.PutBulkJobSpectraS3Request;
+import com.spectralogic.ds3client.commands.spectrads3.PutBulkJobSpectraS3Response;
+import com.spectralogic.ds3client.helpers.Ds3ClientHelpers;
 import com.spectralogic.ds3client.models.bulk.Ds3Object;
 import com.spectralogic.dsbrowser.api.services.logging.LogType;
 import com.spectralogic.dsbrowser.api.services.logging.LoggingService;
-import com.spectralogic.dsbrowser.gui.DeepStorageBrowserPresenter;
-import com.spectralogic.dsbrowser.gui.components.createfolder.CreateFolderModel;
 import com.spectralogic.dsbrowser.gui.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,20 +23,20 @@ public class CreateFolderTask extends Ds3Task {
     private final static Logger LOG = LoggerFactory.getLogger(CreateFolderTask.class);
 
     private final Ds3Client ds3Client;
-    private final CreateFolderModel createFolderModel;
+    private final String bucketName;
     private final String folderName;
     private final List<Ds3Object> ds3ObjectList;
     private final LoggingService loggingService;
     private final ResourceBundle resourceBundle;
 
     public CreateFolderTask(final Ds3Client ds3Client,
-                            final CreateFolderModel createFolderModel,
+                            final String bucketName,
                             final String folderName,
                             final List<Ds3Object> ds3ObjectList,
                             final LoggingService loggingService,
                             final ResourceBundle resourceBundle) {
         this.ds3Client = ds3Client;
-        this.createFolderModel = createFolderModel;
+        this.bucketName = bucketName;
         this.folderName = folderName;
         this.ds3ObjectList = ds3ObjectList;
         this.loggingService = loggingService;
@@ -43,13 +46,12 @@ public class CreateFolderTask extends Ds3Task {
     @Override
     protected Object call() throws Exception {
         try {
-            return ds3Client.putBulkJobSpectraS3(new PutBulkJobSpectraS3Request(createFolderModel.getBucketName().trim(),
-                    ds3ObjectList));
+            return Ds3ClientHelpers.wrap(ds3Client).createFolder(bucketName, folderName);
         } catch (final Exception e) {
             LOG.error("Failed to create folder", e);
             loggingService.logMessage(resourceBundle.getString("createFolderErr")
-                    + StringConstants.SPACE + folderName.trim() + StringConstants.SPACE
-                    + resourceBundle.getString("txtReason")
+                    + StringConstants.SPACE + folderName
+                    + StringConstants.SPACE + resourceBundle.getString("txtReason")
                     + StringConstants.SPACE + e, LogType.ERROR);
             throw e;
         }


### PR DESCRIPTION
…tJob but not actually put the folder, and then the folder would disapear when the job expired after 24 hours

From the server side, the put job and put folder requests both succeed:
```
******************************************************************************
*   HTTP Request #86384 Received   |   Handler: CreatePutJobRequestHandler   *
******************************************************************************
  PUT http://sm2u-11.eng.sldomain.com/_rest_/bucket/DM_TEST
  Headers:
    accept-encoding: 'gzip,deflate'
    authorization: 'AWS QWRtaW5pc3RyYXRvcg==:DE2xVijXDsUa4OoTLpCYU3AaKHc='
    connection: 'Keep-Alive'
    content-length: '48'
    content-type: 'application/xml; charset=ISO-8859-1'
    date: 'Fri, 21 Jul 2017 15:39:15 +0000'
    host: 'sm2u-11.eng.sldomain.com:80'
    naming-convention: 's3'
    user-agent: 'ds3_java_sdk-3.5.0'
  Query Parameters:
    operation: 'start_bulk_put'
  Request:
    URL: http://sm2u-11.eng.sldomain.com/_rest_/bucket/DM_TEST?operation=start_bulk_put
    From: 192.168.20.110
  (RequestDispatcherImpl.handleS3Request:203)
INFO Jul 21 15:38:57,003 [REQ#86384] | Authorization is valid.  User is 'Administrator'.  (S3AuthorizationImpl.validate:93)
INFO Jul 21 15:38:57,003 [REQ#86384] | Dispatching request to CreatePutJobRequestHandler.  (RequestDispatcherImpl.handleS3Request:223)
INFO Jul 21 15:38:57,003 [REQ#86384] | It is invalid to attempt to discover a Bucket where id = DM_TEST.  Will attempt to discover via other properties.  (PostgresDataManager.discover:396)
INFO Jul 21 15:38:57,005 [REQ#86384] | Discovered 1 Bucket where name = DM_TEST.  (PostgresDataManager.discover:382)
INFO Jul 21 15:38:57,008 [REQ#86384] | It is invalid to attempt to discover a Bucket where id = DM_TEST.  Will attempt to discover via other properties.  (PostgresDataManager.discover:396)
INFO Jul 21 15:38:57,009 [REQ#86384] | Discovered 1 Bucket where name = DM_TEST.  (PostgresDataManager.discover:382)
INFO Jul 21 15:38:57,011 [REQ#86384] | Executing CreateJob...  (BaseCommand.execute:20)
INFO Jul 21 15:38:57,011 [REQ#86384] | It is invalid to attempt to discover a Bucket where id = DM_TEST.  Will attempt to discover via other properties.  (PostgresDataManager.discover:396)
INFO Jul 21 15:38:57,012 [REQ#86384] | Discovered 1 Bucket where name = DM_TEST.  (PostgresDataManager.discover:382)
INFO Jul 21 15:38:57,016 [REQ#86384] | For DOM element Objects, parsed attribute priority: null  (SaxXmlAttributeParser.validate:171)
INFO Jul 21 15:38:57,016 [REQ#86384] | For DOM element Objects, parsed attribute chunkClientProcessingOrderGuarantee: null  (SaxXmlAttributeParser.validate:171)
INFO Jul 21 15:38:57,016 [REQ#86384] | For DOM element Objects, parsed attribute writeOptimization: null  (SaxXmlAttributeParser.validate:171)
INFO Jul 21 15:38:57,016 [REQ#86384] | Received client request to create a job with 1 entries.  (CreateJob.executeInternalInternal:162)
INFO Jul 21 15:38:57,018 [REQ#86384] | RPC TargetManager.ping<131228> sent.  (RpcClientImpl.invokeRemoteProcedureCall:204)
INFO Jul 21 15:38:57,020 [RpcResponseDispatcher-1] | [REQ#86384] RPC TargetManager.ping<131228> completed successfully after 1 ms with response: null  (RpcClientUtil.logSuccess:38)
INFO Jul 21 15:38:57,020 [REQ#86384] | RPC TargetManager.createPutJob<131229> sent.  (RpcClientImpl.invokeRemoteProcedureCall:204)
INFO Jul 21 15:38:57,042 [RpcResponseDispatcher-1] | [REQ#86384] RPC TargetManager.createPutJob<131229> completed successfully after 21 ms with response: b9e74125-8103-4830-9267-a1030d4da619  (RpcClientUtil.logSuccess:38)
INFO Jul 21 15:38:57,044 [REQ#86384] | Building JobWithChunksApiBean response for job b9e74125-8103-4830-9267-a1030d4da619...  (JobResponseBuilder.build:66)
INFO Jul 21 15:38:57,052 [REQ#86384] | RPC DataPlanner.ping<131230> sent.  (RpcClientImpl.invokeRemoteProcedureCall:204)
INFO Jul 21 15:38:57,053 [RpcResponseDispatcher-1] | [REQ#86384] RPC DataPlanner.ping<131230> completed successfully after 1 ms with response: null  (RpcClientUtil.logSuccess:38)
INFO Jul 21 15:38:57,053 [REQ#86384] | RPC DataPlanner.getBlobsInCache<131231> sent.  (RpcClientImpl.invokeRemoteProcedureCall:204)
INFO Jul 21 15:38:57,054 [RpcResponseDispatcher-1] | [REQ#86384] RPC DataPlanner.getBlobsInCache<131231> completed successfully after 1 ms with response: {"blobs_in_cache": []}  (RpcClientUtil.logSuccess:38)
INFO Jul 21 15:38:57,055 [REQ#86384] | CreateJob completed in 44 ms.  (BaseCommand.execute:22)
INFO Jul 21 15:38:57,055 [REQ#86384] | CreatePutJobRequestHandler processed request #86384 in 55 ms.  'beanServlet' will provide the response.  (S3Controller.handleS3Request:63)
INFO Jul 21 15:38:57,056 [REQ#86384] | Pushing bean result to client (response type XML)...  (BeanServlet.provideResponse:75)
INFO Jul 21 15:38:57,057 [REQ#86384] |

- HTTP Request #86384 Processed by CreatePutJobRequestHandler
  - Return Code: 200
  - Processing Time: 56 ms
  (BaseServlet.doInternal:151)

INFO Jul 21 15:38:57,187 [http-apr-8080-exec-6] |

******************************************************************************
*   HTTP Request #86385 Received   |   Handler: CreateObjectRequestHandler   *
******************************************************************************
  PUT http://sm2u-11.eng.sldomain.com/DM_TEST/F1/
  Headers:
    accept-encoding: 'gzip,deflate'
    authorization: 'AWS QWRtaW5pc3RyYXRvcg==:ahDkH7YkF3gOk1KsilGo3yBn62k='
    connection: 'Keep-Alive'
    content-length: '0'
    content-type: 'application/xml; charset=ISO-8859-1'
    date: 'Fri, 21 Jul 2017 15:39:16 +0000'
    host: 'sm2u-11.eng.sldomain.com:80'
    naming-convention: 's3'
    user-agent: 'ds3_java_sdk-3.5.0'
  Query Parameters:
    job: 'b9e74125-8103-4830-9267-a1030d4da619'
    offset: '0'
  Request:
    URL: http://sm2u-11.eng.sldomain.com/DM_TEST/F1/?job=b9e74125-8103-4830-9267-a1030d4da619&offset=0
    From: 192.168.20.110
  (RequestDispatcherImpl.handleS3Request:203)
INFO Jul 21 15:38:57,189 [REQ#86385] | Authorization is valid.  User is 'Administrator'.  (S3AuthorizationImpl.validate:93)
INFO Jul 21 15:38:57,189 [REQ#86385] | Dispatching request to CreateObjectRequestHandler.  (RequestDispatcherImpl.handleS3Request:223)
INFO Jul 21 15:38:57,194 [REQ#86385] | Will create 'F1/' in bucket 'DM_TEST'.  (CreateObjectRequestHandler.handleRequestInternal:90)
INFO Jul 21 15:38:57,194 [REQ#86385] | Executing CreateJobIfNecessary...  (BaseCommand.execute:20)
INFO Jul 21 15:38:57,196 [REQ#86385] | CreateJobIfNecessary completed in 2 ms.  (BaseCommand.execute:22)
INFO Jul 21 15:38:57,198 [REQ#86385] | RPC DataPlanner.startBlobWrite<131232> sent.  (RpcClientImpl.invokeRemoteProcedureCall:204)
INFO Jul 21 15:38:57,208 [RpcResponseDispatcher-1] | [REQ#86385] RPC DataPlanner.startBlobWrite<131232> completed successfully after 9 ms with response: /usr/local/bluestorm/frontend/cachedir/77/56/775637d4-11a0-437d-93f2-79474d1ff080  (RpcClientUtil.logSuccess:38)
INFO Jul 21 15:38:57,208 [REQ#86385] | Executing BlobReceiver...  (BaseCommand.execute:20)
INFO Jul 21 15:38:57,212 [REQ#86385] | BlobReceiver completed in 3 ms.  (BaseCommand.execute:22)
INFO Jul 21 15:38:57,212 [REQ#86385] | RPC DataPlanner.blobWriteCompleted<131233> sent.  (RpcClientImpl.invokeRemoteProcedureCall:204)
INFO Jul 21 15:38:57,218 [RpcResponseDispatcher-1] | [REQ#86385] RPC DataPlanner.blobWriteCompleted<131233> completed successfully after 5 ms with response: false  (RpcClientUtil.logSuccess:38)
INFO Jul 21 15:38:57,220 [REQ#86385] | CreateObjectRequestHandler processed request #86385 in 33 ms.  'beanServlet' will provide the response.  (S3Controller.handleS3Request:63)
INFO Jul 21 15:38:57,220 [REQ#86385] | There was no response to write.  The HTTP response code will be the only feedback.  (BeanServlet.provideResponse:71)
INFO Jul 21 15:38:57,220 [REQ#86385] |

- HTTP Request #86385 Processed by CreateObjectRequestHandler
  - Return Code: 200
  - Processing Time: 33 ms
  (BaseServlet.doInternal:151)
```