### PR TITLE
Add an ObjectCompletedListener to the BulkPut job

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
@@ -436,7 +436,7 @@ public class Ds3TreeTablePresenter implements Initializable {
                     }
                     final Ds3PutJob putJob = new Ds3PutJob(session.getClient(), files, bucket, targetDir, priority,
                             settingsStore.getProcessSettings().getMaximumNumberOfParallelThreads(), jobInterruptionStore,
-                            deepStorageBrowserPresenter, session, settingsStore, loggingService, resourceBundle);
+                            deepStorageBrowserPresenter, session, settingsStore, loggingService, resourceBundle, selectedItem);
                     jobWorkers.execute(putJob);
                     putJob.setOnSucceeded(e -> {
                         LOG.info("Succeed");

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
@@ -445,6 +445,7 @@ public class LocalFileTreeTablePresenter implements Initializable {
             if (newValue) {
                 lastExpandedNode = bean;
             }
+            treeTable.requestFocus(); // Update panel and scroll bar if focus shifted
         }));
     }
 
@@ -511,7 +512,7 @@ public class LocalFileTreeTablePresenter implements Initializable {
                              final TreeItem<Ds3TreeTableValue> remoteDestination) {
         final Ds3PutJob putJob = new Ds3PutJob(session.getClient(), files, bucket, targetDir, priority,
                 settingsStore.getProcessSettings().getMaximumNumberOfParallelThreads(), jobInterruptionStore, deepStorageBrowserPresenter,
-                session, settingsStore, loggingService, resourceBundle);
+                session, settingsStore, loggingService, resourceBundle, remoteDestination);
         jobWorkers.execute(putJob);
         putJob.setOnSucceeded(event -> {
             LOG.info("BULK_PUT job {} Succeed.", putJob.getJobId());

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3GetJob.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3GetJob.java
@@ -96,7 +96,7 @@ public class Ds3GetJob extends Ds3JobTask {
     @Override
     public void executeJob() throws Exception {
         if (!CheckNetwork.isReachable(client)) {
-            hostNotAvaialble();
+            hostNotAvailable();
             return;
         }
         final String startJobDate = DateFormat.formatDate(new Date());

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3JobTask.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3JobTask.java
@@ -149,7 +149,7 @@ public abstract class Ds3JobTask extends Task<Boolean> {
         return isJobFailed;
     }
 
-    void hostNotAvaialble() {
+    void hostNotAvailable() {
         final String msg = resourceBundle.getString("host") + SPACE + ds3Client.getConnectionDetails().getEndpoint() + resourceBundle.getString("unreachable");
         ErrorUtils.dumpTheStack(msg);
         loggingService.logMessage(resourceBundle.getString("unableToReachNetwork"), LogType.ERROR);

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
@@ -144,7 +144,6 @@ public class Ds3PutJob extends Ds3JobTask {
 
                 job.attachObjectCompletedListener(obj -> {
                     LOG.info("Object Transfer Completed");
-                    //RefreshCompleteViewWorker.refreshCompleteTreeTableView();
                     final String newDate = DateFormat.formatDate(new Date());
 
                     int index = 0;
@@ -152,15 +151,15 @@ public class Ds3PutJob extends Ds3JobTask {
                         index = obj.lastIndexOf(StringConstants.FORWARD_SLASH);
                     }
 
-                    getTransferRates(jobStartInstant, totalSent, totalJobSize, obj.substring(index, obj.length()), bucket
-                            + StringConstants.FORWARD_SLASH + targetDir);
+                    getTransferRates(jobStartInstant, totalSent, totalJobSize, obj.substring(index, obj.length()),
+                            bucket + StringConstants.FORWARD_SLASH + targetDir);
 
-                    final int finalIndex = index;
                     loggingService.logMessage(
                             StringBuilderUtil.objectSuccessfullyTransferredString(
-                                    obj.substring(finalIndex, obj.length()),
+                                    obj.substring(index, obj.length()),
                                     bucket + StringConstants.FORWARD_SLASH + targetDir, newDate,
                                     resourceBundle.getString("blackPearlCache")).toString(), LogType.SUCCESS);
+                    Platform.runLater(() -> Ds3PanelService.refresh(remoteDestination));
                 });
                 //store meta data to server
                 final boolean isFilePropertiesEnable = settings.getFilePropertiesSettings().isFilePropertiesEnabled();
@@ -170,7 +169,6 @@ public class Ds3PutJob extends Ds3JobTask {
                 }
 
                 addWaitingForChunkListener(totalJobSize, bucket + StringConstants.DOUBLE_SLASH + targetDir);
-                job.attachObjectCompletedListener(object -> Platform.runLater(() -> Ds3PanelService.refresh(remoteDestination)));
                 job.transfer(file -> FileChannel.open(PathUtil.resolveForSymbolic(fileMapper.get(file)), StandardOpenOption.READ));
 
                 waitForPermanentStorageTransfer(totalJobSize);

--- a/dsb-integration/src/test/java/com.spectralogic.dsbrowser.integration/services/newSessionService/NewSessionModelValidationTest.java
+++ b/dsb-integration/src/test/java/com.spectralogic.dsbrowser.integration/services/newSessionService/NewSessionModelValidationTest.java
@@ -13,9 +13,10 @@
  * ******************************************************************************
  */
 
-package com.spectralogic.dsbrowser.gui.services.newSessionService;
+package com.spectralogic.dsbrowser.integration.services.newSessionService;
 
 import com.spectralogic.dsbrowser.gui.components.newsession.NewSessionModel;
+import com.spectralogic.dsbrowser.gui.services.newSessionService.NewSessionModelValidation;
 import org.junit.Test;
 
 

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/CancelJobsWorkerTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/CancelJobsWorkerTest.java
@@ -25,6 +25,7 @@ import com.spectralogic.ds3client.utils.ResourceUtils;
 import com.spectralogic.dsbrowser.api.services.logging.LoggingService;
 import com.spectralogic.dsbrowser.gui.DeepStorageBrowserPresenter;
 import com.spectralogic.dsbrowser.gui.components.ds3panel.Ds3Common;
+import com.spectralogic.dsbrowser.gui.components.ds3panel.ds3treetable.Ds3TreeTableValue;
 import com.spectralogic.dsbrowser.gui.services.BuildInfoServiceImpl;
 import com.spectralogic.dsbrowser.gui.services.JobWorkers;
 import com.spectralogic.dsbrowser.gui.services.Workers;
@@ -45,6 +46,7 @@ import com.spectralogic.dsbrowser.gui.util.ConfigProperties;
 import com.spectralogic.dsbrowser.gui.util.StringConstants;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.scene.control.TreeItem;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -142,9 +144,11 @@ public class CancelJobsWorkerTest {
 
                 //Initiating a put job which to be cancelled
                 final SettingsStore settingsStore = SettingsStore.loadSettingsStore();
+                final TreeItem<Ds3TreeTableValue> destination = new TreeItem<>();
                 final Ds3PutJob ds3PutJob = new Ds3PutJob(ds3Client, filesList, bucketName, StringConstants.EMPTY_STRING,
                          Priority.URGENT.toString(), 5,
-                        JobInterruptionStore.loadJobIds(), deepStorageBrowserPresenter, session, settingsStore, Mockito.mock(LoggingService.class), resourceBundle);
+                        JobInterruptionStore.loadJobIds(), deepStorageBrowserPresenter, session, settingsStore,
+                        Mockito.mock(LoggingService.class), resourceBundle, destination);
 
                 //Starting put job task
                 jobWorkers.execute(ds3PutJob);
@@ -189,12 +193,14 @@ public class CancelJobsWorkerTest {
                 final DeepStorageBrowserPresenter deepStorageBrowserPresenter = Mockito.mock(DeepStorageBrowserPresenter.class);
                 final Ds3Common ds3Common = new Ds3Common();
                 ds3Common.setDeepStorageBrowserPresenter(deepStorageBrowserPresenter);
+                final TreeItem<Ds3TreeTableValue> destination = new TreeItem<>();
 
                 //Initiating put job which to be cancelled
                 final SettingsStore settingsStore = SettingsStore.loadSettingsStore();
                 final Ds3PutJob ds3PutJob = new Ds3PutJob(ds3Client, filesList, bucketName, "",
                         Priority.URGENT.toString(), 5,
-                        JobInterruptionStore.loadJobIds(), deepStorageBrowserPresenter, session, settingsStore, Mockito.mock(LoggingService.class), resourceBundle);
+                        JobInterruptionStore.loadJobIds(), deepStorageBrowserPresenter, session, settingsStore,
+                        Mockito.mock(LoggingService.class), resourceBundle, destination);
 
                 //Starting put job task
                 jobWorkers.execute(ds3PutJob);

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/CloseConfirmationHandlerTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/CloseConfirmationHandlerTest.java
@@ -16,7 +16,6 @@
 package com.spectralogic.dsbrowser.integration;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.spectralogic.ds3client.Ds3Client;
 import com.spectralogic.ds3client.Ds3ClientBuilder;
 import com.spectralogic.ds3client.models.JobRequestType;
@@ -26,6 +25,7 @@ import com.spectralogic.dsbrowser.api.services.ShutdownService;
 import com.spectralogic.dsbrowser.api.services.logging.LoggingService;
 import com.spectralogic.dsbrowser.gui.DeepStorageBrowserPresenter;
 import com.spectralogic.dsbrowser.gui.components.ds3panel.Ds3Common;
+import com.spectralogic.dsbrowser.gui.components.ds3panel.ds3treetable.Ds3TreeTableValue;
 import com.spectralogic.dsbrowser.gui.components.newsession.NewSessionModel;
 import com.spectralogic.dsbrowser.gui.services.BuildInfoServiceImpl;
 import com.spectralogic.dsbrowser.gui.services.JobWorkers;
@@ -50,6 +50,7 @@ import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
 import javafx.embed.swing.JFXPanel;
+import javafx.scene.control.TreeItem;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -253,9 +254,11 @@ public class CloseConfirmationHandlerTest {
                 final SettingsStore settingsStore = SettingsStore.loadSettingsStore();
                 final Ds3Common ds3Common = new Ds3Common();
                 ds3Common.setDeepStorageBrowserPresenter(deepStorageBrowserPresenter);
+                final TreeItem<Ds3TreeTableValue> destination = new TreeItem<>();
                 final Ds3PutJob ds3PutJob = new Ds3PutJob(ds3Client, filesList, "cancelAllTasksBucket", "",
                         Priority.URGENT.toString(), 5, JobInterruptionStore.loadJobIds(),
-                        deepStorageBrowserPresenter, session, settingsStore, Mockito.mock(LoggingService.class), resourceBundle);
+                        deepStorageBrowserPresenter, session, settingsStore, Mockito.mock(LoggingService.class),
+                        resourceBundle, destination);
                 jobWorkers.execute(ds3PutJob);
                 ds3PutJob.setOnSucceeded(event -> {
                     System.out.println("Put job success");

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3PutJobTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3PutJobTest.java
@@ -29,8 +29,10 @@ import com.spectralogic.ds3client.utils.ResourceUtils;
 import com.spectralogic.dsbrowser.api.services.logging.LoggingService;
 import com.spectralogic.dsbrowser.gui.DeepStorageBrowserPresenter;
 import com.spectralogic.dsbrowser.gui.components.ds3panel.Ds3Common;
+import com.spectralogic.dsbrowser.gui.components.ds3panel.ds3treetable.Ds3TreeTableValue;
 import com.spectralogic.dsbrowser.gui.services.BuildInfoServiceImpl;
 import com.spectralogic.dsbrowser.gui.services.JobWorkers;
+import com.spectralogic.dsbrowser.gui.services.ds3Panel.Ds3PanelService;
 import com.spectralogic.dsbrowser.gui.services.jobinterruption.JobInterruptionStore;
 import com.spectralogic.dsbrowser.gui.services.newSessionService.SessionModelService;
 import com.spectralogic.dsbrowser.gui.services.savedSessionStore.SavedCredentials;
@@ -49,6 +51,7 @@ import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.TreeItem;
 import javafx.scene.shape.Circle;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -121,13 +124,14 @@ public class Ds3PutJobTest {
             Mockito.when(ds3Common.getDeepStorageBrowserPresenter()).thenReturn(deepStorageBrowserPresenter);
             final DeepStorageBrowserTaskProgressView<Ds3JobTask> taskProgressView = new DeepStorageBrowserTaskProgressView<>();
             Mockito.when(deepStorageBrowserPresenter.getJobProgressView()).thenReturn(taskProgressView);
+            final TreeItem<Ds3TreeTableValue> destination = new TreeItem<>();
 
             try {
                 final SettingsStore settingsStore = SettingsStore.loadSettingsStore();
                 settingsStore.getShowCachedJobSettings().setShowCachedJob(false);
                 ds3PutJob = new Ds3PutJob(ds3Client, filesList, BUCKET_NAME, "", Priority.URGENT.toString(),
                         5, JobInterruptionStore.loadJobIds(), deepStorageBrowserPresenter,
-                        session, settingsStore, Mockito.mock(LoggingService.class), resourceBundle);
+                        session, settingsStore, Mockito.mock(LoggingService.class), resourceBundle, destination);
                 envDataPolicyId = IntegrationHelpers.setupDataPolicy(TEST_ENV_NAME, false, ChecksumType.Type.MD5, client);
                 envStorageIds = IntegrationHelpers.setup(TEST_ENV_NAME, envDataPolicyId, client);
                 HELPERS.ensureBucketExists(BUCKET_NAME, envDataPolicyId);


### PR DESCRIPTION
Also fix an issue with the scroll bar not rendering in the LocalFileTree after expanding a folder if the focus is elsewhere.