### PR TITLE
Bpb 112 - Show time on waiting for chunks message

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3GetJob.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3GetJob.java
@@ -49,6 +49,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -263,7 +264,7 @@ public class Ds3GetJob extends Ds3JobTask {
 
     private void setWaitingForChunksListener(final int retryAfterSeconds) {
         try {
-            loggingService.logMessage("Attempting Retry", LogType.INFO);
+            loggingService.logMessage("Waiting for chunks, will try again in " + DateFormat.timeConversion(retryAfterSeconds), LogType.INFO);
             Thread.sleep(1000 * retryAfterSeconds);
         } catch (final InterruptedException e) {
             LOG.error("Did not receive chunks before timeout", e);


### PR DESCRIPTION
Minor change, we use the DateUtils to display how long we are going to wait before we try again on chunks that we are waiting for.