### PR TITLE
BPB-182 Progress bar is empty on 0 byte files

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
@@ -260,7 +260,7 @@ public class Ds3PutJob extends Ds3JobTask {
         final boolean isCacheJobEnable = settings.getShowCachedJobSettings().getShowCachedJob();
         final String dateOfTransfer = dateTimeUtils.nowAsString();
         final String finishedMessage = buildFinishedMessage(totalJobSize, isCacheJobEnable, dateOfTransfer, targetDirectory, resourceBundle);
-        updateProgress(totalJobSize, totalJobSize);
+        updateProgress(1, 1);
         updateMessage(finishedMessage);
         loggingService.logMessage(finishedMessage, SUCCESS);
 


### PR DESCRIPTION
By updating to 1/1 we always display correctly.