### PR TITLE
Icon should now be changed back on fail/cancel

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoListTreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoListTreeTableItem.java
@@ -182,6 +182,14 @@ public class JobInfoListTreeTableItem extends TreeItem<JobInfoModel> {
             super.setGraphic(previousGraphics);
             children.setAll(list);
         }));
+        getChildren.setOnCancelled(SafeHandler.logHandle(event -> {
+            super.setGraphic(previousGraphics);
+            children.setAll(list);
+        }));
+        getChildren.setOnFailed(SafeHandler.logHandle(event -> {
+            super.setGraphic(previousGraphics);
+            children.setAll(list);
+        }));
         workers.execute(getChildren);
 
     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
@@ -118,6 +118,14 @@ public class FileTreeTableItem extends TreeItem<FileTreeModel> {
                 LOG.info("Success");
                 super.setGraphic(previousGraphics);
             }));
+            buildChildren.setOnFailed(SafeHandler.logHandle(event -> {
+                LOG.info("Success");
+                super.setGraphic(previousGraphics);
+            }));
+            buildChildren.setOnCancelled(SafeHandler.logHandle(event -> {
+                LOG.info("Success");
+                super.setGraphic(previousGraphics);
+            }));
         }
         return super.getChildren();
     }


### PR DESCRIPTION
We had two places where we never switched back from the spinning icon on cancel/fail.
