### PR TITLE
Fixes for Error Swallowing

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
@@ -111,9 +111,7 @@ public class Ds3PanelPresenter implements Initializable {
     private final Ds3SessionStore ds3SessionStore;
     private final Workers workers;
     private final JobWorkers jobWorkers;
-    private final SavedJobPrioritiesStore savedJobPrioritiesStore;
     private final JobInterruptionStore jobInterruptionStore;
-    private final SettingsStore settingsStore;
     private final DeepStorageBrowserPresenter deepStorageBrowserPresenter;
     private final FileTreeTableProvider fileTreeTableProvider;
     private final Ds3Common ds3Common;
@@ -130,9 +128,7 @@ public class Ds3PanelPresenter implements Initializable {
             final Ds3SessionStore ds3SessionStore,
             final Workers workers,
             final JobWorkers jobWorkers,
-            final SavedJobPrioritiesStore savedJobPrioritiesStore,
             final JobInterruptionStore jobInterruptionStore,
-            final SettingsStore settingsStore,
             final DeepStorageBrowserPresenter deepStorageBrowserPresenter,
             final FileTreeTableProvider fileTreeTableProvider,
             final DateTimeUtils dateTimeUtils,
@@ -145,9 +141,7 @@ public class Ds3PanelPresenter implements Initializable {
         this.ds3SessionStore = ds3SessionStore;
         this.workers = workers;
         this.jobWorkers = jobWorkers;
-        this.savedJobPrioritiesStore = savedJobPrioritiesStore;
         this.jobInterruptionStore = jobInterruptionStore;
-        this.settingsStore = settingsStore;
         this.deepStorageBrowserPresenter = deepStorageBrowserPresenter;
         this.fileTreeTableProvider = fileTreeTableProvider;
         this.ds3Common = ds3Common;
@@ -492,8 +486,8 @@ public class Ds3PanelPresenter implements Initializable {
             refreshLocalSideView(selectedItemsAtDestination, localTreeTableView, localFilePathIndicator, fileRootItem);
         }));
         getJob.setOnFailed(SafeHandler.logHandle(e -> {
-            LOG.info("Get Job {} failed.", getJob.getJobId());
-            refreshLocalSideView(selectedItemsAtDestination, localTreeTableView, localFilePathIndicator, fileRootItem);
+            LOG.error("Get Job failed", e.getSource().getException());
+            loggingService.logMessage("Get Job failed with message: " + e.getSource().getException().getMessage(), LogType.ERROR);
         }));
         getJob.setOnCancelled(SafeHandler.logHandle(e -> {
             LOG.info("Get Job {} cancelled.", getJob.getJobId());

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
@@ -121,6 +121,7 @@ public class Ds3PanelPresenter implements Initializable {
     private final SavedSessionStore savedSessionStore;
     private final LoggingService loggingService;
     private final LazyAlert alert;
+    private final Ds3GetJob.Ds3GetJobFactory getJobFactory;
 
     private GetNoOfItemsTask itemsTask;
 
@@ -137,8 +138,10 @@ public class Ds3PanelPresenter implements Initializable {
             final DateTimeUtils dateTimeUtils,
             final Ds3Common ds3Common,
             final SavedSessionStore savedSessionStore,
+            final Ds3GetJob.Ds3GetJobFactory getJobFactory,
             final LoggingService loggingService) {
         this.resourceBundle = resourceBundle;
+        this.getJobFactory = getJobFactory;
         this.ds3SessionStore = ds3SessionStore;
         this.workers = workers;
         this.jobWorkers = jobWorkers;
@@ -483,12 +486,7 @@ public class Ds3PanelPresenter implements Initializable {
             }
         }
 
-        final String priority = (!savedJobPrioritiesStore.getJobSettings().getGetJobPriority()
-                .equals(resourceBundle.getString("defaultPolicyText"))) ?
-                savedJobPrioritiesStore.getJobSettings().getGetJobPriority() : null;
-        final Ds3GetJob getJob = new Ds3GetJob(selectedItemsAtSourceLocationListCustom, localPath, session.getClient(),
-                priority, settingsStore.getProcessSettings().getMaximumNumberOfParallelThreads(),
-                jobInterruptionStore, deepStorageBrowserPresenter, resourceBundle, dateTimeUtils, loggingService);
+        final Ds3GetJob getJob = getJobFactory.createDs3GetJob(selectedItemsAtSourceLocationListCustom, localPath);
         getJob.setOnSucceeded(SafeHandler.logHandle(event -> {
             LOG.info("Get Job {} succeeded.", getJob.getJobId());
             refreshLocalSideView(selectedItemsAtDestination, localTreeTableView, localFilePathIndicator, fileRootItem);

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTableItem.java
@@ -148,7 +148,7 @@ public class Ds3TreeTableItem extends TreeItem<Ds3TreeTableValue> {
         getBucketTask.setOnFailed(SafeHandler.logHandle(event -> {
             super.setGraphic(previousGraphics);
             loggingService.logMessage("Failed to get bucket", LogType.ERROR);
-            LOG.error("Failed to get bucket", event.getSource().getException());
+            LOG.error("Failed to get bucket");
         }));
         workers.execute(getBucketTask);
     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTableItem.java
@@ -26,6 +26,7 @@ import com.spectralogic.dsbrowser.gui.util.ImageURLs;
 import com.spectralogic.dsbrowser.gui.util.StringConstants;
 import com.spectralogic.dsbrowser.gui.util.treeItem.SafeHandler;
 import javafx.collections.ObservableList;
+import javafx.concurrent.WorkerStateEvent;
 import javafx.scene.Node;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableView;
@@ -145,10 +146,10 @@ public class Ds3TreeTableItem extends TreeItem<Ds3TreeTableValue> {
                 ds3Common.getDs3TreeTableView().setPlaceholder(null);
         }));
         getBucketTask.setOnCancelled(SafeHandler.logHandle(event -> super.setGraphic(previousGraphics)));
-        getBucketTask.setOnFailed(SafeHandler.logHandle(event -> {
+        getBucketTask.setOnFailed(SafeHandler.logHandle((WorkerStateEvent event) -> {
             super.setGraphic(previousGraphics);
             loggingService.logMessage("Failed to get bucket", LogType.ERROR);
-            LOG.error("Failed to get bucket");
+            LOG.error("Failed to get bucket", event.getSource().getException());
         }));
         workers.execute(getBucketTask);
     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTableItem.java
@@ -15,6 +15,7 @@
 
 package com.spectralogic.dsbrowser.gui.components.ds3panel.ds3treetable;
 
+import com.spectralogic.dsbrowser.api.services.logging.LogType;
 import com.spectralogic.dsbrowser.api.services.logging.LoggingService;
 import com.spectralogic.dsbrowser.gui.components.ds3panel.Ds3Common;
 import com.spectralogic.dsbrowser.gui.services.Workers;
@@ -29,10 +30,13 @@ import javafx.scene.Node;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.image.ImageView;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class Ds3TreeTableItem extends TreeItem<Ds3TreeTableValue> {
+    private final static Logger LOG = LoggerFactory.getLogger(Ds3TreeTableItem.class);
+
     private final String bucket;
     private final Session session;
     private final Ds3TreeTableValue ds3Value;
@@ -141,7 +145,11 @@ public class Ds3TreeTableItem extends TreeItem<Ds3TreeTableValue> {
                 ds3Common.getDs3TreeTableView().setPlaceholder(null);
         }));
         getBucketTask.setOnCancelled(SafeHandler.logHandle(event -> super.setGraphic(previousGraphics)));
-        getBucketTask.setOnFailed(SafeHandler.logHandle(event -> super.setGraphic(previousGraphics)));
+        getBucketTask.setOnFailed(SafeHandler.logHandle(event -> {
+            super.setGraphic(previousGraphics);
+            loggingService.logMessage("Failed to get bucket", LogType.ERROR);
+            LOG.error("Failed to get bucket", event.getSource().getException());
+        }));
         workers.execute(getBucketTask);
     }
 

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
@@ -428,7 +428,7 @@ public class Ds3TreeTablePresenter implements Initializable {
                 putJob.setOnFailed(SafeHandler.logHandle(e -> {
                     final Throwable exception = e.getSource().getException();
                     LOG.error("Put Job Failed", exception);
-                    loggingService.logMessage("Put job failed with message: " + exception, LogType.ERROR);
+                    loggingService.logMessage("Put job failed with message: " + exception.getMessage(), LogType.ERROR);
                     Ds3PanelService.refresh(selectedItem);
                     ds3TreeTable.getSelectionModel().clearSelection();
                     ds3TreeTable.getSelectionModel().select(selectedItem);

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
@@ -419,14 +419,15 @@ public class Ds3TreeTablePresenter implements Initializable {
                 }
                 final Ds3PutJob putJob = ds3PutJobFactory.createDs3PutJob(pairs, bucket, targetDir, selectedItem);
                 putJob.setOnSucceeded(SafeHandler.logHandle(e -> {
-                    LOG.info("Succeed");
+                    LOG.info("Put Job Succeed");
                     Ds3PanelService.refresh(selectedItem);
                     ds3TreeTable.getSelectionModel().clearSelection();
                     ds3TreeTable.getSelectionModel().select(selectedItem);
 
                 }));
                 putJob.setOnFailed(SafeHandler.logHandle(e -> {
-                    LOG.info("setOnFailed");
+                    LOG.info("Put Job Failed", e.getSource().getException());
+                    loggingService.logMessage("Put job failed with message: " + e.getSource().getException().getMessage(), LogType.ERROR);
                     Ds3PanelService.refresh(selectedItem);
                     ds3TreeTable.getSelectionModel().clearSelection();
                     ds3TreeTable.getSelectionModel().select(selectedItem);

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
@@ -426,7 +426,8 @@ public class Ds3TreeTablePresenter implements Initializable {
 
                 }));
                 putJob.setOnFailed(SafeHandler.logHandle(e -> {
-                    LOG.info("Put Job Failed", e.getSource().getException());
+                    final Throwable exception = e.getSource().getException();
+                    LOG.error("Put Job Failed", exception);
                     loggingService.logMessage("Put job failed with message: " + e.getSource().getException().getMessage(), LogType.ERROR);
                     Ds3PanelService.refresh(selectedItem);
                     ds3TreeTable.getSelectionModel().clearSelection();

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
@@ -428,7 +428,7 @@ public class Ds3TreeTablePresenter implements Initializable {
                 putJob.setOnFailed(SafeHandler.logHandle(e -> {
                     final Throwable exception = e.getSource().getException();
                     LOG.error("Put Job Failed", exception);
-                    loggingService.logMessage("Put job failed with message: " + e.getSource().getException().getMessage(), LogType.ERROR);
+                    loggingService.logMessage("Put job failed with message: " + exception, LogType.ERROR);
                     Ds3PanelService.refresh(selectedItem);
                     ds3TreeTable.getSelectionModel().clearSelection();
                     ds3TreeTable.getSelectionModel().select(selectedItem);

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
@@ -257,8 +257,8 @@ public class JobInfoPresenter implements Initializable {
                         LOG.info("Cancellation of recovered job success");
                         refresh(buttonCell.getTreeTableView(), jobInterruptionStore, endpointInfo);
                     }));
-                    ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle(cancelJobTaskFailedEvent -> {
-                        LOG.info("Cancellation of interrupted job " + jobId + " failed");
+                    ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle((WorkerStateEvent cancelJobTaskFailedEvent) -> {
+                        LOG.error("Cancellation of interrupted job " + jobId + " failed", cancelJobTaskFailedEvent.getSource().getException());
                     }));
                     ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle((WorkerStateEvent event) -> {
                         LOG.error("Cancellation of recovered job failed", event.getSource().getException());
@@ -376,8 +376,8 @@ public class JobInfoPresenter implements Initializable {
             treeTableView.setRoot(rootTreeItem);
             treeTableView.setPlaceholder(new Label(resourceBundle.getString("dontHaveInterruptedJobs")));
         }));
-        getJobIDs.setOnFailed(SafeHandler.logHandle(event -> {
-            LOG.error("Get Job IDs failed");
+        getJobIDs.setOnFailed(SafeHandler.logHandle((WorkerStateEvent event) -> {
+            LOG.error("Get Job IDs failed", event.getSource().getException());
             loggingService.logMessage("Get Job IDs failed", LogType.ERROR);
             treeTableView.setRoot(rootTreeItem);
             treeTableView.setPlaceholder(new Label(resourceBundle.getString("dontHaveInterruptedJobs")));

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
@@ -259,6 +259,10 @@ public class JobInfoPresenter implements Initializable {
                     ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle(cancelJobTaskFailedEvent -> {
                         LOG.info("Cancellation of interrupted job " + jobId + " failed");
                     }));
+                    ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle(event -> {
+                        LOG.error("Cancellation of recoved job faile", event.getSource().getException());
+                        loggingService.logMessage("Cancellation of recoved job failed", LogType.ERROR);
+                    }));
 
                     workers.execute(ds3CancelSingleJobTask);
                 }));
@@ -372,6 +376,8 @@ public class JobInfoPresenter implements Initializable {
             treeTableView.setPlaceholder(new Label(resourceBundle.getString("dontHaveInterruptedJobs")));
         }));
         getJobIDs.setOnFailed(SafeHandler.logHandle(event -> {
+            LOG.error("Get Job IDs failed", event.getSource().getException());
+            loggingService.logMessage("Get Job IDs failed", LogType.ERROR);
             treeTableView.setRoot(rootTreeItem);
             treeTableView.setPlaceholder(new Label(resourceBundle.getString("dontHaveInterruptedJobs")));
         }));

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
@@ -241,6 +241,7 @@ public class JobInfoPresenter implements Initializable {
                     refresh(buttonCell.getTreeTableView(), jobInterruptionStore, endpointInfo);
                 }));
                 recoverInterruptedJob.setOnFailed(SafeHandler.logHandle(recoverInterruptedJobFailedEvent -> {
+                    LOG.error("Failed to recover", recoverInterruptedJob.getException());
                     loggingService.logMessage("Failed to recover " + filesAndFolderMap.getType() + " job " + endpointInfo.getEndpoint(), LogType.ERROR);
                     refresh(buttonCell.getTreeTableView(), jobInterruptionStore, endpointInfo);
                 }));
@@ -306,6 +307,7 @@ public class JobInfoPresenter implements Initializable {
                 }));
                 recoverInterruptedJob.setOnFailed(SafeHandler.logHandle(event -> {
                     loggingService.logMessage("Failed to recover " + value.getType() + " job " + endpointInfo.getEndpoint(), LogType.ERROR);
+                    LOG.error("Failed to recover Job", event.getSource().getException());
                     refresh(jobListTreeTable, jobInterruptionStore, endpointInfo);
                     RefreshCompleteViewWorker.refreshCompleteTreeTableView(ds3Common, workers, dateTimeUtils, loggingService);
                 }));

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
@@ -246,7 +246,7 @@ public class JobInfoPresenter implements Initializable {
                     loggingService.logMessage("Failed to recover " + filesAndFolderMap.getType() + " job " + endpointInfo.getEndpoint(), LogType.ERROR);
                     refresh(buttonCell.getTreeTableView(), jobInterruptionStore, endpointInfo);
                 }));
-                recoverInterruptedJob.setOnCancelled(SafeHandler.logHandle((WorkerStateEvent recoverInterruptedJobCancelledEvent) -> {
+                recoverInterruptedJob.setOnCancelled(SafeHandler.logHandle(recoverInterruptedJobCancelledEvent -> {
                     final Ds3CancelSingleJobTask ds3CancelSingleJobTask = new Ds3CancelSingleJobTask(
                             jobId,
                             endpointInfo,
@@ -256,9 +256,6 @@ public class JobInfoPresenter implements Initializable {
                     ds3CancelSingleJobTask.setOnSucceeded(SafeHandler.logHandle(eventCancel -> {
                         LOG.info("Cancellation of recovered job success");
                         refresh(buttonCell.getTreeTableView(), jobInterruptionStore, endpointInfo);
-                    }));
-                    ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle((WorkerStateEvent cancelJobTaskFailedEvent) -> {
-                        LOG.error("Cancellation of interrupted job " + jobId + " failed", cancelJobTaskFailedEvent.getSource().getException());
                     }));
                     ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle((WorkerStateEvent event) -> {
                         LOG.error("Cancellation of recovered job failed", event.getSource().getException());

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
@@ -33,6 +33,7 @@ import com.spectralogic.dsbrowser.gui.util.treeItem.SafeHandler;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.concurrent.Task;
+import javafx.concurrent.WorkerStateEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
@@ -245,7 +246,7 @@ public class JobInfoPresenter implements Initializable {
                     loggingService.logMessage("Failed to recover " + filesAndFolderMap.getType() + " job " + endpointInfo.getEndpoint(), LogType.ERROR);
                     refresh(buttonCell.getTreeTableView(), jobInterruptionStore, endpointInfo);
                 }));
-                recoverInterruptedJob.setOnCancelled(SafeHandler.logHandle(recoverInterruptedJobCancelledEvent -> {
+                recoverInterruptedJob.setOnCancelled(SafeHandler.logHandle((WorkerStateEvent recoverInterruptedJobCancelledEvent) -> {
                     final Ds3CancelSingleJobTask ds3CancelSingleJobTask = new Ds3CancelSingleJobTask(
                             jobId,
                             endpointInfo,
@@ -259,8 +260,8 @@ public class JobInfoPresenter implements Initializable {
                     ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle(cancelJobTaskFailedEvent -> {
                         LOG.info("Cancellation of interrupted job " + jobId + " failed");
                     }));
-                    ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle(event -> {
-                        LOG.error("Cancellation of recoved job faile");
+                    ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle((WorkerStateEvent event) -> {
+                        LOG.error("Cancellation of recovered job failed", event.getSource().getException());
                         loggingService.logMessage("Cancellation of recoved job failed", LogType.ERROR);
                     }));
 

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/interruptedjobwindow/JobInfoPresenter.java
@@ -260,7 +260,7 @@ public class JobInfoPresenter implements Initializable {
                         LOG.info("Cancellation of interrupted job " + jobId + " failed");
                     }));
                     ds3CancelSingleJobTask.setOnFailed(SafeHandler.logHandle(event -> {
-                        LOG.error("Cancellation of recoved job faile", event.getSource().getException());
+                        LOG.error("Cancellation of recoved job faile");
                         loggingService.logMessage("Cancellation of recoved job failed", LogType.ERROR);
                     }));
 
@@ -376,7 +376,7 @@ public class JobInfoPresenter implements Initializable {
             treeTableView.setPlaceholder(new Label(resourceBundle.getString("dontHaveInterruptedJobs")));
         }));
         getJobIDs.setOnFailed(SafeHandler.logHandle(event -> {
-            LOG.error("Get Job IDs failed", event.getSource().getException());
+            LOG.error("Get Job IDs failed");
             loggingService.logMessage("Get Job IDs failed", LogType.ERROR);
             treeTableView.setRoot(rootTreeItem);
             treeTableView.setPlaceholder(new Label(resourceBundle.getString("dontHaveInterruptedJobs")));

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
@@ -119,7 +119,7 @@ public class FileTreeTableItem extends TreeItem<FileTreeModel> {
                 super.setGraphic(previousGraphics);
             }));
             buildChildren.setOnFailed(SafeHandler.logHandle(event -> {
-                LOG.info("Failed to build children", event.getSource().getException());
+                LOG.info("Failed to build children");
                 super.setGraphic(previousGraphics);
             }));
             buildChildren.setOnCancelled(SafeHandler.logHandle(event -> {

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
@@ -119,7 +119,7 @@ public class FileTreeTableItem extends TreeItem<FileTreeModel> {
                 super.setGraphic(previousGraphics);
             }));
             buildChildren.setOnFailed(SafeHandler.logHandle(event -> {
-                LOG.info("Success");
+                LOG.info("Failed to build children", event.getSource().getException());
                 super.setGraphic(previousGraphics);
             }));
             buildChildren.setOnCancelled(SafeHandler.logHandle(event -> {

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
@@ -26,6 +26,7 @@ import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView;
 import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
+import javafx.concurrent.WorkerStateEvent;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.Node;
 import javafx.scene.control.Tooltip;
@@ -118,8 +119,8 @@ public class FileTreeTableItem extends TreeItem<FileTreeModel> {
                 LOG.info("Success");
                 super.setGraphic(previousGraphics);
             }));
-            buildChildren.setOnFailed(SafeHandler.logHandle(event -> {
-                LOG.info("Failed to build children");
+            buildChildren.setOnFailed(SafeHandler.logHandle((WorkerStateEvent event) -> {
+                LOG.error("Failed to build children", event.getSource().getException());
                 super.setGraphic(previousGraphics);
             }));
             buildChildren.setOnCancelled(SafeHandler.logHandle(event -> {

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
@@ -449,8 +449,9 @@ public class LocalFileTreeTablePresenter implements Initializable {
             refreshFileTreeView();
         }));
         getJob.setOnFailed(SafeHandler.logHandle(event -> {
-            LOG.error("Get Job failed", event.getSource().getException());
-            loggingService.logMessage("Get Job failed with message: " + event.getSource().getException().getMessage(), LogType.ERROR);
+            final Throwable exception = event.getSource().getException();
+            LOG.error("Get Job failed", exception);
+            loggingService.logMessage("Get Job failed with message: " + exception.getMessage(), LogType.ERROR);
             refreshFileTreeView();
         }));
         getJob.setOnCancelled(SafeHandler.logHandle(cancelEvent -> {
@@ -480,8 +481,9 @@ public class LocalFileTreeTablePresenter implements Initializable {
             refreshBlackPearlSideItem(remoteDestination);
         }));
         putJob.setOnFailed(SafeHandler.logHandle(failEvent -> {
-            LOG.error("Put Job Failed", failEvent.getSource().getException());
-            loggingService.logMessage("Put Job Failed with message: " + failEvent.getSource().getException().getMessage(), LogType.ERROR);
+            final Throwable throwable = failEvent.getSource().getException();
+            LOG.error("Put Job Failed", throwable);
+            loggingService.logMessage("Put Job Failed with message: " + throwable.getMessage(), LogType.ERROR);
         }));
         putJob.setOnCancelled(SafeHandler.logHandle(cancelEvent -> {
             final UUID jobId = putJob.getJobId();

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3JobTask.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3JobTask.java
@@ -56,13 +56,7 @@ public abstract class Ds3JobTask extends Task<Boolean> {
     @Override
     protected final Boolean call() throws Exception {
         LOG.info("Starting DS3 Job");
-        try {
-            executeJob();
-        } catch (final Throwable e) {
-            LOG.error("Job failed with an exception: " + e.getMessage(), e);
-            return false;
-        }
-        LOG.info("Job finished successfully");
+        executeJob();
         return true;
     }
 
@@ -119,7 +113,7 @@ public abstract class Ds3JobTask extends Task<Boolean> {
                     totalJobSize, sourceLocation, targetLocation).toString());
         }
 
-        updateProgress(totalSent.get() / 2 , totalJobSize);
+        updateProgress(totalSent.get() / 2, totalJobSize);
     }
 
     void updateInterruptedJobsBtn(final JobInterruptionStore jobInterruptionStore, final UUID jobId) {

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/RefreshCompleteViewWorker.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/RefreshCompleteViewWorker.java
@@ -95,7 +95,7 @@ public final class RefreshCompleteViewWorker {
                         }
                     }));
                     getServiceTask.setOnFailed(SafeHandler.logHandle(event -> {
-                        LOG.info("GetServiceTask failed");
+                        LOG.error("GetServiceTask failed", event);
                         loggingService.logMessage("Get Service Task failed", LogType.ERROR);
                         ds3TreeTableView.setRoot(null);
                     }));

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/RefreshCompleteViewWorker.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/RefreshCompleteViewWorker.java
@@ -95,7 +95,8 @@ public final class RefreshCompleteViewWorker {
                         }
                     }));
                     getServiceTask.setOnFailed(SafeHandler.logHandle(event -> {
-                        LOG.info("GetServiceTask failed");
+                        LOG.info("GetServiceTask failed", event.getSource().getException());
+                        loggingService.logMessage("Get Service Task failed", LogType.ERROR);
                         ds3TreeTableView.setRoot(null);
                     }));
                     workers.execute(getServiceTask);

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/RefreshCompleteViewWorker.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/RefreshCompleteViewWorker.java
@@ -95,7 +95,7 @@ public final class RefreshCompleteViewWorker {
                         }
                     }));
                     getServiceTask.setOnFailed(SafeHandler.logHandle(event -> {
-                        LOG.info("GetServiceTask failed", event.getSource().getException());
+                        LOG.info("GetServiceTask failed");
                         loggingService.logMessage("Get Service Task failed", LogType.ERROR);
                         ds3TreeTableView.setRoot(null);
                     }));

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3GetJob_Test.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3GetJob_Test.java
@@ -36,6 +36,7 @@ import com.spectralogic.dsbrowser.gui.services.newSessionService.SessionModelSer
 import com.spectralogic.dsbrowser.gui.services.savedSessionStore.SavedCredentials;
 import com.spectralogic.dsbrowser.gui.services.savedSessionStore.SavedSession;
 import com.spectralogic.dsbrowser.gui.services.sessionStore.Session;
+import com.spectralogic.dsbrowser.gui.services.settings.SettingsStore;
 import com.spectralogic.dsbrowser.gui.services.tasks.CreateConnectionTask;
 import com.spectralogic.dsbrowser.gui.services.tasks.Ds3GetJob;
 import com.spectralogic.dsbrowser.gui.services.tasks.Ds3JobTask;
@@ -118,7 +119,7 @@ public class Ds3GetJob_Test {
             Mockito.when(deepStorageBrowserPresenter.getJobProgressView()).thenReturn(taskProgressView);
 
             try {
-                ds3GetJob = new Ds3GetJob(listTreeTable, path, ds3Client, Priority.URGENT.toString(), 5, Mockito.mock(JobInterruptionStore.class), deepStorageBrowserPresenter, resourceBundle, DTU, Mockito.mock(LoggingService.class));
+                ds3GetJob = new Ds3GetJob(listTreeTable, path, ds3Client, Priority.URGENT.toString(), 5, Mockito.mock(JobInterruptionStore.class), deepStorageBrowserPresenter, resourceBundle, DTU, SettingsStore.createDefaultSettingStore(), Mockito.mock(LoggingService.class));
                 taskProgressView.getTasks().add(ds3GetJob);
                 envDataPolicyId = IntegrationHelpers.setupDataPolicy(TEST_ENV_NAME, false, ChecksumType.Type.MD5, client);
                 envStorageIds = IntegrationHelpers.setup(TEST_ENV_NAME, envDataPolicyId, client);


### PR DESCRIPTION
Three changes in this pull request:
Stop swallowing on failure from workers, mostly in DS3JobTask
Ensure logging takes place on setOnFailure. Searched for everywhere we setOnFailure and tried to make sure we log. All over the place
In order to make sure I didn't miss places I ended up replacing JobTask constructors with Guice Factories to simplify things.
One Liner: We now check settings correctly before setting the metadata receiver in Ds3GetJob
