### PR TITLE
Bpb 252

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
@@ -102,7 +102,7 @@ public class Ds3PutJob extends Ds3JobTask {
                     try {
                         return new Pair<>(p.getKey().replace(delimiter, BP_DELIMITER), FileUtils.resolveForSymbolic(p.getValue()));
                     } catch (final IOException e) {
-                        loggingService.logMessage("Could not readd from filesystem, skipping item " + p.getValue().toString(), LogType.ERROR);
+                        loggingService.logMessage("Could not read from filesystem, skipping item " + p.getValue().toString(), LogType.ERROR);
                         LOG.error("Could not read from filesystem", e);
                         return null;
                     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
@@ -102,7 +102,7 @@ public class Ds3PutJob extends Ds3JobTask {
                     try {
                         return new Pair<>(p.getKey().replace(delimiter, BP_DELIMITER), FileUtils.resolveForSymbolic(p.getValue()));
                     } catch (final IOException e) {
-                        loggingService.logMessage("Could not readd from filesystem, aborting put job", LogType.ERROR);
+                        loggingService.logMessage("Could not readd from filesystem, skipping item", LogType.ERROR);
                         LOG.error("Could not read from filesystem", e);
                         return null;
                     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
@@ -102,7 +102,7 @@ public class Ds3PutJob extends Ds3JobTask {
                     try {
                         return new Pair<>(p.getKey().replace(delimiter, BP_DELIMITER), FileUtils.resolveForSymbolic(p.getValue()));
                     } catch (final IOException e) {
-                        loggingService.logMessage("Could not readd from filesystem, skipping item", LogType.ERROR);
+                        loggingService.logMessage("Could not readd from filesystem, skipping item " + p.getValue().toString(), LogType.ERROR);
                         LOG.error("Could not read from filesystem", e);
                         return null;
                     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/Ds3PutJob.java
@@ -104,9 +104,11 @@ public class Ds3PutJob extends Ds3JobTask {
                     } catch (final IOException e) {
                         loggingService.logMessage("Could not readd from filesystem, aborting put job", LogType.ERROR);
                         LOG.error("Could not read from filesystem", e);
-                        return new Pair<String, Path>(null,null);
+                        return null;
                     }
-                }).collect(GuavaCollectors.immutableList());
+                })
+                .filter(Objects::nonNull)
+                .collect(GuavaCollectors.immutableList());
         this.settings = settings;
         this.bucket = bucket;
         this.targetDir = targetDir;


### PR DESCRIPTION
Changes:
Short-circuit and show a message on an empty putJob
No longer follow symbolic links in Files.Walk
Follow symbolic links for files and folders passed to us directly, but preserve symbolic link name. (IE if  /foo/bar/test.txt is a symbolic link, it will show up in the BP as /foo/bar/test.txt, not the symbolic linked resolved path)
