### PR TITLE
BPB-245: Ds3 Table Node Expand inconsistent

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
@@ -188,26 +188,27 @@ public class Ds3PanelPresenter implements Initializable {
      */
     private void goToParentDirectory() {
         //if root is null back button will not work
-        if (null != getTreeTableView().getRoot().getValue() &&
-                null != getTreeTableView().getRoot().getParent()) {
-            if (null == getTreeTableView().getRoot().getParent().getValue()) {
-                getDs3PathIndicator().setText(StringConstants.EMPTY_STRING);
-                getDs3PathIndicator().setTooltip(null);
+        final TreeItem<Ds3TreeTableValue> root = getTreeTableView().getRoot();
+        final Label ds3PathIndicator = getDs3PathIndicator();
+        if (null != root.getValue() && null != root.getParent()) {
+            if (null == root.getParent().getValue()) {
+                ds3PathIndicator.setText(StringConstants.EMPTY_STRING);
+                ds3PathIndicator.setTooltip(null);
                 capacityLabel.setText(StringConstants.EMPTY_STRING);
                 capacityLabel.setVisible(false);
                 infoLabel.setText(StringConstants.EMPTY_STRING);
                 infoLabel.setVisible(false);
             } else {
-                getDs3PathIndicator().setTooltip(getDs3PathIndicatorTooltip());
+                ds3PathIndicator.setTooltip(getDs3PathIndicatorTooltip());
             }
-            getTreeTableView().setRoot(getTreeTableView().getRoot().getParent());
-            getTreeTableView().getRoot().getChildren().forEach(treeItem -> treeItem.setExpanded(false));
+            getTreeTableView().setRoot(root.getParent());
+            root.getChildren().forEach(treeItem -> treeItem.setExpanded(false));
             final ProgressIndicator progress = new ProgressIndicator();
             progress.setMaxSize(90, 90);
-            ds3Common.getDs3PanelPresenter().getTreeTableView().refresh();
+            getTreeTableView().refresh();
         } else {
-            getDs3PathIndicator().setText(StringConstants.EMPTY_STRING);
-            getDs3PathIndicator().setTooltip(null);
+            ds3PathIndicator.setText(StringConstants.EMPTY_STRING);
+            ds3PathIndicator.setTooltip(null);
 
         }
     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTableItem.java
@@ -156,7 +156,7 @@ public class Ds3TreeTableItem extends TreeItem<Ds3TreeTableValue> {
 
     @Override
     public boolean isLeaf() {
-        return leaf;
+        return getChildren().isEmpty();
     }
 
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
@@ -54,7 +54,6 @@ import javafx.scene.effect.InnerShadow;
 import javafx.scene.input.*;
 import javafx.scene.layout.StackPane;
 import javafx.util.Pair;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -232,20 +231,7 @@ public class Ds3TreeTablePresenter implements Initializable {
 
         ds3TreeTable.setRoot(rootTreeItem);
 
-        ds3TreeTable.expandedItemCountProperty().addListener(getNumberChangeListener());
-
-        final GetServiceTask getServiceTask = new GetServiceTask(rootTreeItem.getChildren(), session, workers, ds3Common, dateTimeUtils, loggingService);
-        LOG.info("Getting buckets from {}", session.getEndpoint());
-
-        progress.progressProperty().bind(getServiceTask.progressProperty());
-
-        Platform.runLater(() -> getServiceTask.setOnSucceeded(buildPlaceHolder(oldPlaceHolder)));
-        workers.execute(getServiceTask);
-    }
-
-    @NotNull
-    private ChangeListener<Number> getNumberChangeListener() {
-        return (observable, oldValue, newValue) -> {
+        ds3TreeTable.expandedItemCountProperty().addListener((observable, oldValue, newValue) -> {
             if (ds3Common.getCurrentSession() != null) {
                 LOG.info("Loading Session {}", session.getSessionName());
 
@@ -264,7 +250,15 @@ public class Ds3TreeTablePresenter implements Initializable {
                 ds3PanelPresenter.setBlank(true);
                 ds3PanelPresenter.disableSearch(true);
             }
-        };
+        });
+
+        final GetServiceTask getServiceTask = new GetServiceTask(rootTreeItem.getChildren(), session, workers, ds3Common, dateTimeUtils, loggingService);
+        LOG.info("Getting buckets from {}", session.getEndpoint());
+
+        progress.progressProperty().bind(getServiceTask.progressProperty());
+
+        Platform.runLater(() -> getServiceTask.setOnSucceeded(buildPlaceHolder(oldPlaceHolder)));
+        workers.execute(getServiceTask);
     }
 
     private EventHandler buildPlaceHolder(final Node oldPlaceHolder) {


### PR DESCRIPTION
This change removes code that tries to decide if we should show the expand node, and instead uses the isLeaf method like the JavaFX documents say we should.
