### PR TITLE
BPBROWSER-265 - Sorting causes null pointer

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
@@ -15,6 +15,7 @@
 
 package com.spectralogic.dsbrowser.gui.components.localfiletreetable;
 
+import ch.qos.logback.core.joran.conditional.ThenOrElseActionBase;
 import com.spectralogic.dsbrowser.gui.services.Workers;
 import com.spectralogic.dsbrowser.gui.util.DateTimeUtils;
 import com.spectralogic.dsbrowser.gui.util.ImageURLs;
@@ -86,7 +87,7 @@ public class FileTreeTableItem extends TreeItem<FileTreeModel> {
             );
             icon.paintIcon(null, bufferedImage.getGraphics(), 0, 0);
             return new ImageView(SwingFXUtils.toFXImage(bufferedImage, null));
-        } catch (final Exception e) {
+        } catch (final Throwable e) {
             LOG.error("Unable to get FileSystem Icon", e);
             return getGraphicFont(fileTreeModel);
         }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItem.java
@@ -15,7 +15,6 @@
 
 package com.spectralogic.dsbrowser.gui.components.localfiletreetable;
 
-import ch.qos.logback.core.joran.conditional.ThenOrElseActionBase;
 import com.spectralogic.dsbrowser.gui.services.Workers;
 import com.spectralogic.dsbrowser.gui.util.DateTimeUtils;
 import com.spectralogic.dsbrowser.gui.util.ImageURLs;

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
@@ -278,14 +278,14 @@ public class LocalFileTreeTablePresenter implements Initializable {
         final ObservableList<TreeItem<FileTreeModel>> currentLocalSelection = treeTable.getSelectionModel().getSelectedItems();
         final ImmutableList<Pair<String, Path>> files = currentLocalSelection
                 .stream()
-                .map(i -> new Pair<>(i.getValue().getName(), i.getValue().getPath()))
+                .map(TreeItem::getValue)
+                .filter(Objects::nonNull)
+                .map(i -> new Pair<>(i.getName(), i.getPath()))
                 .collect(GuavaCollectors.immutableList());
-
         if (files.isEmpty()) {
             ds3Common.getDs3TreeTableView().refresh();
             return null;
         }
-
         return files;
     }
 


### PR DESCRIPTION
By filtering out empty items from the filesystem we can cause the calling method to display an error popup, instead of a silent failure.