### PR TITLE
We now prevent the user from viewing or manipulating a directory when…

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
@@ -465,26 +465,29 @@ public class Ds3PanelPresenter implements Initializable {
             final TreeTableView<FileTreeModel> treeTable,
             final Label fileRootItemLabel,
             final String fileRootItem) {
+        final TreeItem<FileTreeModel> rootTreeItem = new TreeItem<>();
         final Optional<TreeItem<FileTreeModel>> first = selectedItemsAtDestination.stream().findFirst();
         if (first.isPresent()) {
             final TreeItem<FileTreeModel> selectedItem = first.get();
             if (selectedItem instanceof FileTreeTableItem) {
                 final FileTreeTableItem fileTreeTableItem = (FileTreeTableItem) selectedItem;
-                fileTreeTableItem.refresh();
-                treeTable.getSelectionModel().clearSelection();
-                treeTable.getSelectionModel().select(selectedItem);
+                try {
+                    fileTreeTableItem.refresh();
+                    treeTable.getSelectionModel().clearSelection();
+                    treeTable.getSelectionModel().select(selectedItem);
+                } catch (final IOException e) {
+                    treeTable.setRoot(rootTreeItem);
+                }
             }
         } else {
-            final TreeItem<FileTreeModel> rootTreeItem = new TreeItem<>();
             rootTreeItem.setExpanded(true);
             treeTable.setShowRoot(false);
             final Stream<FileTreeModel> rootItems = fileTreeTableProvider.getRoot(fileRootItem, dateTimeUtils);
             fileRootItemLabel.setText(fileRootItem);
             rootItems.forEach(ftm -> {
-                final TreeItem<FileTreeModel> newRootTreeItem = new FileTreeTableItem(fileTreeTableProvider, ftm, dateTimeUtils, workers);
+                final TreeItem<FileTreeModel> newRootTreeItem = new FileTreeTableItem(fileTreeTableProvider, ftm, dateTimeUtils, workers, loggingService);
                 rootTreeItem.getChildren().add(newRootTreeItem);
             });
-
             treeTable.setRoot(rootTreeItem);
         }
     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/GetMediaDeviceTask.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/GetMediaDeviceTask.java
@@ -15,6 +15,7 @@
 
 package com.spectralogic.dsbrowser.gui.services.tasks;
 
+import com.spectralogic.dsbrowser.api.services.logging.LoggingService;
 import com.spectralogic.dsbrowser.gui.components.localfiletreetable.FileTreeModel;
 import com.spectralogic.dsbrowser.gui.components.localfiletreetable.FileTreeTableItem;
 import com.spectralogic.dsbrowser.gui.util.DateTimeUtils;
@@ -32,20 +33,22 @@ public class GetMediaDeviceTask extends Task{
     private final FileTreeTableProvider provider;
     private final Workers workers;
     private final DateTimeUtils dateTimeUtils;
+    private final LoggingService loggingService;
 
-    public GetMediaDeviceTask(final Stream<FileTreeModel> rootItems, final TreeItem<FileTreeModel> rootTreeItem, final FileTreeTableProvider provider, final DateTimeUtils dateTimeUtils, final Workers workers) {
+    public GetMediaDeviceTask(final Stream<FileTreeModel> rootItems, final TreeItem<FileTreeModel> rootTreeItem, final FileTreeTableProvider provider, final DateTimeUtils dateTimeUtils, final Workers workers, final LoggingService loggingService) {
         this.rootItems = rootItems;
         this.rootTreeItem = rootTreeItem;
         this.provider = provider;
         this.workers = workers;
         this.dateTimeUtils = dateTimeUtils;
+        this.loggingService = loggingService;
     }
 
     @Override
     protected Optional<Object> call() throws Exception {
         rootItems.forEach(ftm ->
                 {
-                    final TreeItem<FileTreeModel> newRootTreeItem = new FileTreeTableItem(provider, ftm, dateTimeUtils, workers);
+                    final TreeItem<FileTreeModel> newRootTreeItem = new FileTreeTableItem(provider, ftm, dateTimeUtils, workers, loggingService);
                     rootTreeItem.getChildren().add(newRootTreeItem);
                 }
         );

--- a/dsb-gui/src/main/resources/lang_en.properties
+++ b/dsb-gui/src/main/resources/lang_en.properties
@@ -357,7 +357,7 @@ networkConError=Network connection error
 noTaskRunning=No tasks running
 filesAndFolders=files/folders have been loaded inside
 eonbrowser=Eon Browser
-
+unableToReadFileSystem=Unable to Read from file system
 
 
 

--- a/dsb-gui/src/test/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItemTest.java
+++ b/dsb-gui/src/test/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/FileTreeTableItemTest.java
@@ -16,6 +16,8 @@
 package com.spectralogic.dsbrowser.gui.components.localfiletreetable;
 
 import com.spectralogic.ds3client.utils.ResourceUtils;
+import com.spectralogic.dsbrowser.api.services.logging.LoggingService;
+import com.spectralogic.dsbrowser.gui.services.LoggingServiceImpl;
 import com.spectralogic.dsbrowser.gui.services.Workers;
 import com.spectralogic.dsbrowser.gui.util.DateTimeUtils;
 import com.spectralogic.dsbrowser.gui.util.FileTreeTableProvider;
@@ -43,6 +45,7 @@ import static org.junit.Assert.fail;
 public class FileTreeTableItemTest {
 
     final private DateTimeUtils dateTimeUtils = new DateTimeUtils(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    final private LoggingService loggingService = new LoggingServiceImpl();
     private boolean successFlag =  false;
 
     @Test
@@ -50,7 +53,7 @@ public class FileTreeTableItemTest {
         final Path path = ResourceUtils.loadFileResource(SessionConstants.LOCAL_FOLDER + SessionConstants.LOCAL_FILE);
         final FileTreeModel fileTreeModel = new FileTreeModel(path, FileTreeModel.Type.File, Files.size(path), 0, "");
         final FileTreeTableProvider fileTreeTableProvider = Mockito.mock(FileTreeTableProvider.class);
-        final FileTreeTableItem fileTreeTableItem = new FileTreeTableItem(fileTreeTableProvider, fileTreeModel, dateTimeUtils, new Workers());
+        final FileTreeTableItem fileTreeTableItem = new FileTreeTableItem(fileTreeTableProvider, fileTreeModel, dateTimeUtils, new Workers(), loggingService);
         Assert.assertNotNull(fileTreeTableItem.getGraphicType(fileTreeModel));
     }
 
@@ -59,7 +62,7 @@ public class FileTreeTableItemTest {
         final Path path = ResourceUtils.loadFileResource(SessionConstants.LOCAL_FOLDER + SessionConstants.LOCAL_FILE);
         final FileTreeTableProvider fileTreeTableProvider = Mockito.mock(FileTreeTableProvider.class);
         final FileTreeModel fileTreeModel = new FileTreeModel(path, FileTreeModel.Type.File, Files.size(path), 0, "");
-        Assert.assertTrue(new FileTreeTableItem(fileTreeTableProvider, fileTreeModel, dateTimeUtils, new Workers()).isLeaf());
+        Assert.assertTrue(new FileTreeTableItem(fileTreeTableProvider, fileTreeModel, dateTimeUtils, new Workers(), loggingService).isLeaf());
     }
 
     @Test
@@ -67,7 +70,7 @@ public class FileTreeTableItemTest {
         final Path path = ResourceUtils.loadFileResource(SessionConstants.LOCAL_FOLDER + SessionConstants.LOCAL_FILE);
         final FileTreeTableProvider fileTreeTableProvider = Mockito.mock(FileTreeTableProvider.class);
         final FileTreeModel fileTreeModel = new FileTreeModel(path, FileTreeModel.Type.Directory, 0, 0, "");
-        Assert.assertNotNull(new FileTreeTableItem(fileTreeTableProvider, fileTreeModel, dateTimeUtils, new Workers()).getGraphicFont(fileTreeModel));
+        Assert.assertNotNull(new FileTreeTableItem(fileTreeTableProvider, fileTreeModel, dateTimeUtils, new Workers(), loggingService).getGraphicFont(fileTreeModel));
     }
 
     @Test
@@ -81,14 +84,14 @@ public class FileTreeTableItemTest {
                 final int numFiles = testFolder.list().length;
                 final FileTreeTableProvider fileTreeTableProvider = new FileTreeTableProvider();
                 final FileTreeModel fileTreeModel = new FileTreeModel(path, FileTreeModel.Type.Directory, 0, 0, "");
-                final FileTreeTableItem fileTreeTableItem = new FileTreeTableItem(fileTreeTableProvider, fileTreeModel, dateTimeUtils, new Workers());
+                final FileTreeTableItem fileTreeTableItem = new FileTreeTableItem(fileTreeTableProvider, fileTreeModel, dateTimeUtils, new Workers(), loggingService);
                 fileTreeTableItem.refresh();
                 final ObservableList<TreeItem<FileTreeModel>> children = fileTreeTableItem.getChildren();
                 if (children.size() == numFiles) {
                     successFlag = true;
                 }
                 latch.countDown();
-            } catch (final FileNotFoundException | URISyntaxException e) {
+            } catch (final URISyntaxException | IOException e) {
                 e.printStackTrace();
                 latch.countDown();
                 fail();

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/GetMediaDeviceTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/GetMediaDeviceTaskTest.java
@@ -15,7 +15,9 @@
 
 package com.spectralogic.dsbrowser.integration.tasks;
 
+import com.spectralogic.dsbrowser.api.services.logging.LoggingService;
 import com.spectralogic.dsbrowser.gui.components.localfiletreetable.FileTreeModel;
+import com.spectralogic.dsbrowser.gui.services.LoggingServiceImpl;
 import com.spectralogic.dsbrowser.gui.services.Workers;
 import com.spectralogic.dsbrowser.gui.services.tasks.GetMediaDeviceTask;
 import com.spectralogic.dsbrowser.gui.util.DateTimeUtils;
@@ -37,6 +39,7 @@ import static org.junit.Assert.assertTrue;
 public class GetMediaDeviceTaskTest {
 
     private static final DateTimeUtils DTU = new DateTimeUtils(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    private final LoggingService loggingService = new LoggingServiceImpl();
     private boolean successFlag = false;
 
     @Test
@@ -51,7 +54,7 @@ public class GetMediaDeviceTaskTest {
                 Mockito.when(treeItem.getChildren()).thenReturn(FXCollections.observableArrayList());
                 final Workers workers = new Workers();
 
-                final GetMediaDeviceTask task = new GetMediaDeviceTask(rootItems, treeItem, provider, DTU, workers);
+                final GetMediaDeviceTask task = new GetMediaDeviceTask(rootItems, treeItem, provider, DTU, workers, loggingService);
                 workers.execute(task);
                 task.setOnSucceeded(event -> {
                     successFlag = true;


### PR DESCRIPTION
… the filesytem could not be read instead the pane becomes blank and the Logs pane indicates we could not read the filesystem