### PR TITLE
You can no longer select a file for create folder BPB-458

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
@@ -543,7 +543,7 @@ public class Ds3TreeTablePresenter implements Initializable {
                             deleteFile.setDisable(false);
                             metaData.setDisable(false);
                             versioning.setDisable(false);
-                            createFolder.setDisable(false);
+                            createFolder.setDisable(true);
                             break;
                         default:
                             break;


### PR DESCRIPTION
This prevents a user confusion as to where the folder is being created.