### PR TITLE
Bpb456

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/DeepStorageBrowserPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/DeepStorageBrowserPresenter.java
@@ -52,6 +52,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.StrokeType;
+import javafx.stage.Window;
 import org.controlsfx.control.TaskProgressView;
 import org.fxmisc.richtext.InlineCssTextArea;
 import org.slf4j.Logger;
@@ -242,7 +243,7 @@ public class DeepStorageBrowserPresenter implements Initializable {
                 if (!Guard.isMapNullOrEmpty(jobIDMap)) {
                     recoverInterruptedJobsButton.setDisable(false);
                     final JobInfoView jobView = new JobInfoView(new EndpointInfo(endpoint, session.getClient(), jobIDMap, this, ds3Common));
-                    popup.show(jobView.getView(), resourceBundle.getString("interruptedJobsPopUp") + StringConstants.SPACE + endpoint);
+                    popup.show(jobView.getView(), resourceBundle.getString("interruptedJobsPopUp") + StringConstants.SPACE + endpoint, getWindow());
                 } else {
                     recoverInterruptedJobsButton.setDisable(true);
                 }
@@ -341,16 +342,16 @@ public class DeepStorageBrowserPresenter implements Initializable {
 
     public void showSettingsPopup() {
         final SettingsView settingsView = new SettingsView();
-        popup.show(settingsView.getView(), resourceBundle.getString("settingsMenuItem"), true);
+        popup.show(settingsView.getView(), resourceBundle.getString("settingsMenuItem"), true, getWindow());
     }
 
     public void showAboutPopup() {
         final AboutView aboutView = new AboutView();
-        popup.show(aboutView.getView(), resourceBundle.getString("aboutMenuItem"));
+        popup.show(aboutView.getView(), resourceBundle.getString("aboutMenuItem"), getWindow());
     }
 
     public void showSessionPopup() {
-        popup.show(new NewSessionView().getView(), resourceBundle.getString("sessionsMenuItem"));
+        popup.show(new NewSessionView().getView(), resourceBundle.getString("sessionsMenuItem"), getWindow());
     }
 
     public void selectAllItemsInPane() {
@@ -440,5 +441,9 @@ public class DeepStorageBrowserPresenter implements Initializable {
 
     public TaskProgressView<Ds3JobTask> getJobProgressView() {
         return jobProgressView;
+    }
+
+    private Window getWindow() {
+        return anchorPane.getScene().getWindow();
     }
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createbucket/CreateBucketPopup.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createbucket/CreateBucketPopup.java
@@ -16,6 +16,7 @@
 package com.spectralogic.dsbrowser.gui.components.createbucket;
 
 import com.spectralogic.dsbrowser.gui.util.Popup;
+import javafx.stage.Window;
 
 import javax.inject.Inject;
 import java.util.ResourceBundle;
@@ -34,8 +35,8 @@ public final class CreateBucketPopup {
         this.popup = popup;
     }
 
-    public void show(final CreateBucketWithDataPoliciesModel createBucketModel) {
+    public void show(final CreateBucketWithDataPoliciesModel createBucketModel, final Window window) {
         final CreateBucketView createBucketView = new CreateBucketView(createBucketModel);
-        popup.show(createBucketView.getView(), resourceBundle.getString("createBucketContextMenu"));
+        popup.show(createBucketView.getView(), resourceBundle.getString("createBucketContextMenu"), window);
     }
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createbucket/CreateBucketPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createbucket/CreateBucketPresenter.java
@@ -30,6 +30,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.*;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,20 +144,20 @@ public class CreateBucketPresenter implements Initializable {
                     });
                 }));
                 createBucketTask.setOnFailed(SafeHandler.logHandle(event -> {
-                    alert.error(CREATE_BUCKET_ERROR_ALERT);
+                    alert.error(CREATE_BUCKET_ERROR_ALERT, getWindow());
                 }));
                 workers.execute(createBucketTask);
             } else {
                 LOG.info("Data policy not found");
                 loggingService.logMessage(resourceBundle.getString(DATA_POLICY_NOT_FOUND_ERR), LogType.INFO);
-                alert.error(DATA_POLICY_NOT_FOUND_ERR);
+                alert.error(DATA_POLICY_NOT_FOUND_ERR, getWindow());
             }
 
 
         } catch (final Exception e) {
             LOG.error("Failed to create bucket", e);
             loggingService.logMessage(resourceBundle.getString("createBucketFailedErr") + e, LogType.ERROR);
-            alert.error(CREATE_BUCKET_ERROR_ALERT);
+            alert.error(CREATE_BUCKET_ERROR_ALERT, getWindow());
         }
     }
 
@@ -168,5 +169,9 @@ public class CreateBucketPresenter implements Initializable {
     private void closeDialog() {
         final Stage popupStage = (Stage) bucketNameField.getScene().getWindow();
         popupStage.close();
+    }
+
+    private Window getWindow() {
+        return dataPolicyComboLabel.getScene().getWindow();
     }
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createfolder/CreateFolderPopup.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createfolder/CreateFolderPopup.java
@@ -16,6 +16,7 @@
 package com.spectralogic.dsbrowser.gui.components.createfolder;
 
 import com.spectralogic.dsbrowser.gui.util.Popup;
+import javafx.stage.Window;
 
 import javax.inject.Inject;
 import java.util.ResourceBundle;
@@ -31,8 +32,8 @@ public class CreateFolderPopup {
         this.resourceBundle = resourceBundle;
     }
 
-    public void show(final CreateFolderModel createFolderModel) {
+    public void show(final CreateFolderModel createFolderModel, final Window window) {
         final CreateFolderView createFolderView = new CreateFolderView(createFolderModel);
-        popup.show(createFolderView.getView(), resourceBundle.getString("createFolderButton"));
+        popup.show(createFolderView.getView(), resourceBundle.getString("createFolderButton"), window);
     }
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createfolder/CreateFolderPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/createfolder/CreateFolderPresenter.java
@@ -32,6 +32,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,9 +118,9 @@ public class CreateFolderPresenter implements Initializable {
         createFolderTask.setOnFailed(SafeHandler.logHandle(event -> {
             final Throwable e = event.getSource().getException();
             if (e instanceof FailedRequestException && ((FailedRequestException) e).getError().getCode().equals("OBJECT_ALREADY_EXISTS")) {
-                alert.error("folderAlreadyExists");
+                alert.error("folderAlreadyExists", getWindow());
             } else {
-                alert.error(CREATE_FOLDER_ERR_LOGS);
+                alert.error(CREATE_FOLDER_ERR_LOGS, getWindow());
                 LOG.error("Failed to create folder", e);
                 loggingService.logMessage(resourceBundle.getString("createFolderErr")
                         + StringConstants.SPACE + folderNameField.textProperty().getValue().trim()
@@ -139,5 +140,9 @@ public class CreateFolderPresenter implements Initializable {
     private void closeDialog() {
         final Stage popupStage = (Stage) folderNameField.getScene().getWindow();
         popupStage.close();
+    }
+
+    private Window getWindow() {
+        return labelText.getScene().getWindow();
     }
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/deletefiles/DeleteFilesPopup.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/deletefiles/DeleteFilesPopup.java
@@ -21,6 +21,7 @@ import com.spectralogic.dsbrowser.gui.util.Ds3Task;
 import com.spectralogic.dsbrowser.gui.util.Popup;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TreeItem;
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,22 +49,22 @@ public class DeleteFilesPopup {
     }
 
 
-    public void show(final Ds3Task deleteTask) {
+    public void show(final Ds3Task deleteTask, final Window window) {
         final DeleteItemView deleteView = new DeleteItemView(deleteTask);
         if (ds3Common.getDs3TreeTableView() != null) {
             final ObservableList<TreeItem<Ds3TreeTableValue>> selectedPanelItems = ds3Common.getDs3TreeTableView().getSelectionModel().getSelectedItems();
-            changeLabelText(selectedPanelItems, deleteView);
+            changeLabelText(selectedPanelItems, deleteView, window);
         }
     }
 
     private void changeLabelText(final ObservableList<TreeItem<Ds3TreeTableValue>> selectedItems,
-            final DeleteItemView deleteView) {
+            final DeleteItemView deleteView, final Window window) {
         if (selectedItems.get(0).getValue().getType() == (Ds3TreeTableValue.Type.File)) {
-            popup.show(deleteView.getView(), resourceBundle.getString("deleteFiles"));
+            popup.show(deleteView.getView(), resourceBundle.getString("deleteFiles"), window);
         } else if (selectedItems.get(0).getValue().getType() == (Ds3TreeTableValue.Type.Directory)) {
-            popup.show(deleteView.getView(), resourceBundle.getString("deleteFolder"));
+            popup.show(deleteView.getView(), resourceBundle.getString("deleteFolder"), window);
         } else {
-            popup.show(deleteView.getView(), resourceBundle.getString("deleteBucket"));
+            popup.show(deleteView.getView(), resourceBundle.getString("deleteBucket"), window);
         }
 
     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/deletefiles/DeleteItemPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/deletefiles/DeleteItemPresenter.java
@@ -38,6 +38,7 @@ import javafx.fxml.Initializable;
 import javafx.scene.control.*;
 import javafx.scene.input.KeyCode;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -180,6 +181,10 @@ public class DeleteItemPresenter implements Initializable {
         loggingService.logMessage(message, LogType.ERROR);
 
         closeDialog();
-        alert.error(alertMessage);
+        alert.error(alertMessage, getWindow());
+    }
+
+    private Window getWindow() {
+        return deleteLabel.getScene().getWindow();
     }
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/ds3treetable/Ds3TreeTablePresenter.java
@@ -51,6 +51,7 @@ import javafx.scene.control.*;
 import javafx.scene.effect.InnerShadow;
 import javafx.scene.input.*;
 import javafx.scene.layout.StackPane;
+import javafx.stage.Window;
 import javafx.util.Pair;
 import kotlin.Unit;
 import org.slf4j.Logger;
@@ -174,16 +175,16 @@ public class Ds3TreeTablePresenter implements Initializable {
         physicalPlacement.setOnAction(SafeHandler.logHandle(event -> ds3PanelService.showPhysicalPlacement()));
 
         versioning = new MenuItem(resourceBundle.getString("versioningContextMenu"));
-        versioning.setOnAction(SafeHandler.logHandle(event -> ds3PanelService.showVersions()));
+        versioning.setOnAction(SafeHandler.logHandle(event -> ds3PanelService.showVersions(getWindow())));
 
         metaData = new MenuItem(resourceBundle.getString("metaDataContextMenu"));
-        metaData.setOnAction(SafeHandler.logHandle(event -> ds3PanelService.showMetadata()));
+        metaData.setOnAction(SafeHandler.logHandle(event -> ds3PanelService.showMetadata(getWindow())));
 
         createBucket = new MenuItem(resourceBundle.getString("createBucketContextMenu"));
-        createBucket.setOnAction(SafeHandler.logHandle(event -> createService.createBucketPrompt()));
+        createBucket.setOnAction(SafeHandler.logHandle(event -> createService.createBucketPrompt(getWindow())));
 
         createFolder = new MenuItem(resourceBundle.getString("createFolderContextMenu"));
-        createFolder.setOnAction(SafeHandler.logHandle(event -> createService.createFolderPrompt()));
+        createFolder.setOnAction(SafeHandler.logHandle(event -> createService.createFolderPrompt(getWindow())));
 
         contextMenu.getItems().addAll(metaData, physicalPlacement, versioning, new SeparatorMenuItem(), deleteFile, deleteFolder, deleteBucket, new SeparatorMenuItem(), createBucket, createFolder);
     }
@@ -416,7 +417,7 @@ public class Ds3TreeTablePresenter implements Initializable {
                 }
                 startPutJob(session.getClient(), pairs, bucket, targetDir, selectedItem);
             } else {
-                alert.warning("operationNotAllowedHere");
+                alert.warning("operationNotAllowedHere", getWindow());
             }
             event.consume();
         } catch (final Throwable t) {
@@ -715,5 +716,8 @@ public class Ds3TreeTablePresenter implements Initializable {
                 });
     }
 
+    private Window getWindow() {
+        return ds3TreeTable.getScene().getWindow();
+    }
 
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
@@ -44,6 +44,7 @@ import javafx.scene.control.*;
 import javafx.scene.effect.InnerShadow;
 import javafx.scene.input.*;
 import javafx.scene.layout.StackPane;
+import javafx.stage.Window;
 import javafx.util.Pair;
 import kotlin.Unit;
 import org.slf4j.Logger;
@@ -256,7 +257,7 @@ public class LocalFileTreeTablePresenter implements Initializable {
 
     private void createFolder() {
         if (fileRootItem.equals("My Computer")) {
-            alert.error("specifyDirectory");
+            alert.error("specifyDirectory", getWindow());
             return;
         }
         final Path rootPath = Paths.get(fileRootItem);
@@ -270,14 +271,14 @@ public class LocalFileTreeTablePresenter implements Initializable {
         if (results.isPresent()) {
             final String folderName = results.get();
             if (Guard.isStringNullOrEmpty(folderName)) {
-                alert.error("cannotCreateFolderWithoutName");
+                alert.error("cannotCreateFolderWithoutName", getWindow());
                 return;
             }
             try {
                 Files.createDirectories(rootPath.resolve(folderName));
                 refreshFileTreeView();
             } catch (final IOException e) {
-                alert.error("couldNotCreateLocalDirectory");
+                alert.error("couldNotCreateLocalDirectory", getWindow());
                 loggingService.logMessage(resourceBundle.getString("couldNotCreateLocalDirectory"), LogType.ERROR);
                 LOG.error("Could not create directory in " + rootPath.toString(), LogType.ERROR);
             }
@@ -345,7 +346,7 @@ public class LocalFileTreeTablePresenter implements Initializable {
                 return null;
             }
         } else if (currentRemoteSelection.size() > 1) {
-            alert.error("multipleDestError");
+            alert.error("multipleDestError", getWindow());
             return null;
         }
 
@@ -356,16 +357,16 @@ public class LocalFileTreeTablePresenter implements Initializable {
         final Session session = ds3Common.getCurrentSession();
         if (session == null) {
             LOG.error("No valid session to initiate Put");
-            alert.error("noSession");
+            alert.error("noSession", getWindow());
             return;
         }
 
         final TreeItem<Ds3TreeTableValue> remoteDestination = getRemoteDestination(); // The TreeItem is required to refresh the view
         if (remoteDestination == null || remoteDestination.getValue() == null) {
-            alert.info("selectDestination");
+            alert.info("selectDestination", getWindow());
             return;
         } else if (remoteDestination.getValue().isSearchOn()) {
-            alert.info("operationNotAllowed");
+            alert.info("operationNotAllowed", getWindow());
             return;
         } else if (!remoteDestination.isExpanded()) {
             remoteDestination.setExpanded(true);
@@ -379,7 +380,7 @@ public class LocalFileTreeTablePresenter implements Initializable {
         // Get local files to PUT
         final ImmutableList<kotlin.Pair<String, Path>> filesToPut = getLocalFilesToPut();
         if (Guard.isNullOrEmpty(filesToPut)) {
-            alert.info("fieSelect");
+            alert.info("fieSelect", getWindow());
             return;
         }
 
@@ -564,5 +565,9 @@ public class LocalFileTreeTablePresenter implements Initializable {
             }
         }
         return localPath;
+    }
+
+    public Window getWindow() {
+        return treeTable.getScene().getWindow();
     }
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/localfiletreetable/LocalFileTreeTablePresenter.java
@@ -51,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -58,7 +59,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Stream;
-
+@Singleton
 @Presenter
 public class LocalFileTreeTablePresenter implements Initializable {
 

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/modifyjobpriority/ModifyJobPriorityPopUp.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/modifyjobpriority/ModifyJobPriorityPopUp.java
@@ -16,6 +16,7 @@
 package com.spectralogic.dsbrowser.gui.components.modifyjobpriority;
 
 import com.spectralogic.dsbrowser.gui.util.Popup;
+import javafx.stage.Window;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -33,9 +34,9 @@ public final class ModifyJobPriorityPopUp {
         this.popup = popup;
     }
 
-    public void show(final ModifyJobPriorityModel value) {
+    public void show(final ModifyJobPriorityModel value, final Window window) {
         final ModifyJobPriorityView view = new ModifyJobPriorityView(value);
-        popup.show(view.getView(), resourceBundle.getString("changeJobPriority"));
+        popup.show(view.getView(), resourceBundle.getString("changeJobPriority"), window);
     }
 
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/newsession/NewSessionPopup.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/newsession/NewSessionPopup.java
@@ -17,6 +17,7 @@ package com.spectralogic.dsbrowser.gui.components.newsession;
 
 import com.spectralogic.dsbrowser.gui.components.ds3panel.Ds3Common;
 import com.spectralogic.dsbrowser.gui.util.Popup;
+import javafx.stage.Window;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -35,8 +36,8 @@ public class NewSessionPopup {
        this.resourceBundle = resourceBundle;
        this.popup = popup;
     }
-    public void show() {
+    public void show(final Window window) {
         final NewSessionView view = new NewSessionView();
-        popup.show(view.getView(), resourceBundle.getString("sessionsMenuItem"));
+        popup.show(view.getView(), resourceBundle.getString("sessionsMenuItem"), window);
     }
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/settings/SettingPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/settings/SettingPresenter.java
@@ -30,6 +30,7 @@ import javafx.fxml.Initializable;
 import javafx.scene.control.*;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import javafx.util.converter.NumberStringConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,7 +162,7 @@ public class SettingPresenter implements Initializable {
         }
     }
 
-    public void saveFilePropertiesSettings() {
+    public void saveFilePropertiesSettings(final Window window) {
         LOG.info("Updating fileProperties settingsStore");
         try {
             if (filePropertiesCheckbox.isSelected()) {
@@ -169,33 +170,33 @@ public class SettingPresenter implements Initializable {
             } else {
                 settingsStore.setFilePropertiesSettings(false);
             }
-            alert.info("filePropertiesSettingsUpdated");
+            alert.info("filePropertiesSettingsUpdated", window);
         } catch (final Exception e) {
             LOG.error("Failed to save file properties", e);
         }
     }
 
-    public void savePerformanceSettings() {
+    public void savePerformanceSettings(final Window window) {
         LOG.info("Updating maximum number of Threads");
         settingsStore.setProcessSettings(processSettings);
         jobWorkers.setWorkers(Executors.newFixedThreadPool(processSettings.getMaximumNumberOfParallelThreads()));
-        alert.info("performanceSettingsUpdated");
+        alert.info("performanceSettingsUpdated", window);
     }
 
-    public void saveLogSettings() {
+    public void saveLogSettings(final Window window) {
         LOG.info("Updating logging settingsStore");
         settingsStore.setLogSettings(logSettings);
         applicationLoggerSettings.setLogSettings(logSettings);
-        alert.info("loggingSettingsUpdated");
+        alert.info("loggingSettingsUpdated", window);
     }
 
-    public void saveJobSettings() {
+    public void saveJobSettings(final Window window) {
         LOG.info("Updating jobs settingsStore");
         try {
             jobSettings.setGetJobPriority(getJobPriority.getSelectionModel().getSelectedItem());
             jobSettings.setPutJobPriority(putJobPriority.getSelectionModel().getSelectedItem());
             SavedJobPrioritiesStore.saveSavedJobPriorties(savedJobPrioritiesStore);
-            alert.info("jobsSettingsUpdated");
+            alert.info("jobsSettingsUpdated", window);
         } catch (final Exception e) {
             LOG.error("Failed to save job priorities", e);
         }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/version/VersionPopup.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/version/VersionPopup.java
@@ -29,6 +29,7 @@ import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +57,7 @@ public class VersionPopup {
         this.alertService = alertService;
     }
 
-    public void show(final Ds3TreeTableValue item) {
+    public void show(final Ds3TreeTableValue item, final Window window) {
         Platform.runLater(() -> {
             final List<VersionItem> versions = getVersioned(item)
                     .stream()
@@ -64,7 +65,7 @@ public class VersionPopup {
                     .collect(GuavaCollectors.immutableList());
 
             if (versions.isEmpty()) {
-                alertService.warning("unableToGetVersions");
+                alertService.warning("unableToGetVersions", window);
             } else {
                 final Stage popup = new Stage();
                 popup.initOwner(ds3Common.getWindow());

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/ds3Panel/DeleteService.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/ds3Panel/DeleteService.java
@@ -35,6 +35,7 @@ import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableView;
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,7 @@ public final class DeleteService {
      *
      * @param values    list of objects to be deleted
      */
-    public void deleteBucket(final ImmutableList<TreeItem<Ds3TreeTableValue>> values) {
+    public void deleteBucket(final ImmutableList<TreeItem<Ds3TreeTableValue>> values, final Window window) {
         LOG.info("Got delete bucket event");
 
         final Ds3PanelPresenter ds3PanelPresenter = ds3Common.getDs3PanelPresenter();
@@ -89,7 +90,7 @@ public final class DeleteService {
             if (buckets.size() > 1) {
                 loggingService.logMessage(resourceBundle.getString("multiBucketNotAllowed"), LogType.ERROR);
                 LOG.info("The user selected objects from multiple buckets.  This is not allowed.");
-                alert.error("multiBucketNotAllowed");
+                alert.error("multiBucketNotAllowed", window);
                 return;
             }
             final Optional<TreeItem<Ds3TreeTableValue>> first = values.stream().findFirst();
@@ -98,10 +99,10 @@ public final class DeleteService {
                 final String bucketName = value.getValue().getBucketName();
                 if (!ds3PanelService.checkIfBucketEmpty(bucketName, currentSession)) {
                     loggingService.logMessage(resourceBundle.getString("failedToDeleteBucket"), LogType.ERROR);
-                    alert.error("failedToDeleteBucket");
+                    alert.error("failedToDeleteBucket", window);
                 } else {
                     final Ds3DeleteBucketTask ds3DeleteBucketTask = new Ds3DeleteBucketTask(currentSession.getClient(), bucketName);
-                    deleteFilesPopup.show(ds3DeleteBucketTask);
+                    deleteFilesPopup.show(ds3DeleteBucketTask, window);
                     ds3Common.getDs3TreeTableView().setRoot(new TreeItem<>());
                     refreshCompleteViewWorker.refreshCompleteTreeTableView();
                     ds3PanelPresenter.getDs3PathIndicator().setText(StringConstants.EMPTY_STRING);
@@ -118,7 +119,7 @@ public final class DeleteService {
      *
      * @param values    list of folders to be deleted
      */
-    public void deleteFolders(final ImmutableList<TreeItem<Ds3TreeTableValue>> values) {
+    public void deleteFolders(final ImmutableList<TreeItem<Ds3TreeTableValue>> values, final Window window) {
         LOG.info("Got delete folder event");
 
         final Ds3PanelPresenter ds3PanelPresenter = ds3Common.getDs3PanelPresenter();
@@ -130,7 +131,7 @@ public final class DeleteService {
             final Ds3DeleteFoldersTask deleteFolderTask = new Ds3DeleteFoldersTask(currentSession.getClient(),
                     deleteFoldersMap.build());
 
-            deleteFilesPopup.show(deleteFolderTask);
+            deleteFilesPopup.show(deleteFolderTask, window);
             ds3PanelPresenter.getDs3PathIndicator().setText(StringConstants.EMPTY_STRING);
             ds3PanelPresenter.getDs3PathIndicatorTooltip().setText(StringConstants.EMPTY_STRING);
         }
@@ -141,7 +142,7 @@ public final class DeleteService {
      *
      * @param values    list of objects to be deleted
      */
-    public void deleteFiles(final ImmutableList<TreeItem<Ds3TreeTableValue>> values) {
+    public void deleteFiles(final ImmutableList<TreeItem<Ds3TreeTableValue>> values, final Window window) {
         LOG.info("Got delete file(s) event");
 
         final ImmutableList<String> buckets = getBuckets(values);
@@ -156,7 +157,7 @@ public final class DeleteService {
         final Ds3DeleteFilesTask ds3DeleteFilesTask = new Ds3DeleteFilesTask(
                 ds3Common.getCurrentSession().getClient(), buckets, bucketObjectsMap);
 
-        deleteFilesPopup.show(ds3DeleteFilesTask);
+        deleteFilesPopup.show(ds3DeleteFilesTask, window);
     }
 
     public void managePathIndicator() {

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/ds3Panel/Ds3PanelService.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/ds3Panel/Ds3PanelService.java
@@ -45,6 +45,7 @@ import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.control.*;
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,7 +182,7 @@ public final class Ds3PanelService {
                 });
     }
 
-    public void showMetadata() {
+    public void showMetadata(final Window window) {
         getSelectedItems()
                 .stream()
                 .findFirst()
@@ -191,7 +192,7 @@ public final class Ds3PanelService {
                     getMetadata.setOnSucceeded(SafeHandler.logHandle(event -> Platform.runLater(() -> {
                         LOG.info("Launching metadata popup");
                         final MetadataView metadataView = new MetadataView(getMetadata.getValue());
-                        popup.show(metadataView.getView(), resourceBundle.getString("metaDataContextMenu"), true);
+                        popup.show(metadataView.getView(), resourceBundle.getString("metaDataContextMenu"), true, window);
                     })));
                 });
     }
@@ -262,12 +263,12 @@ public final class Ds3PanelService {
 
     }
 
-    public void showVersions() {
+    public void showVersions(final Window window) {
         final ObservableList<TreeItem<Ds3TreeTableValue>> selectedItems = getSelectedItems();
         selectedItems.stream()
                 .findFirst()
                 .ifPresent(item -> {
-                    versionPopup.show(item.getValue());
+                    versionPopup.show(item.getValue(), window);
                 });
     }
 

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/newSessionService/NewSessionModelValidation.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/newSessionService/NewSessionModelValidation.java
@@ -18,6 +18,7 @@ package com.spectralogic.dsbrowser.gui.services.newSessionService;
 import com.spectralogic.dsbrowser.gui.components.newsession.NewSessionModel;
 import com.spectralogic.dsbrowser.gui.components.validation.SessionValidation;
 import com.spectralogic.dsbrowser.gui.util.AlertService;
+import javafx.stage.Window;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -33,21 +34,21 @@ public class NewSessionModelValidation {
 
     public static final String ERROR = "Error";
 
-    public boolean validationNewSession(final NewSessionModel model) {
+    public boolean validationNewSession(final NewSessionModel model, final Window window) {
         if (!SessionValidation.checkStringEmptyNull(model.getSessionName())) {
-            alert.error("enterSession");
+            alert.error("enterSession", window);
             return false;
         } else if (!SessionValidation.checkStringEmptyNull(model.getEndpoint())) {
-            alert.error("enterDataPathAddress");
+            alert.error("enterDataPathAddress", window);
             return false;
         } else if (!SessionValidation.validatePort(model.getPortNo().trim())) {
-            alert.error("enterValidPort");
+            alert.error("enterValidPort", window);
             return false;
         } else if (!SessionValidation.checkStringEmptyNull(model.getAccessKey())) {
-            alert.error("enterAccessKey");
+            alert.error("enterAccessKey", window);
             return false;
         } else if (!SessionValidation.checkStringEmptyNull(model.getSecretKey())) {
-            alert.error("enterSecretKey");
+            alert.error("enterSecretKey", window);
             return false;
         }
         return true;

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/savedSessionStore/SavedSessionStore.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/savedSessionStore/SavedSessionStore.java
@@ -26,6 +26,7 @@ import com.spectralogic.dsbrowser.gui.util.StringConstants;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,18 +119,18 @@ public class SavedSessionStore {
     }
 
     //open default session when DSB launched
-    public void openDefaultSession(final Ds3SessionStore store, final CreateConnectionTask createConnectionTask) {
+    public void openDefaultSession(final Ds3SessionStore store, final CreateConnectionTask createConnectionTask, final Window window) {
         getSessions().stream()
                 .filter(Objects::nonNull)
                 .filter(SavedSession::getDefaultSession)
                 .findFirst()
-                .ifPresent(savedSession -> connectToDefaultSession(store, savedSession, createConnectionTask));
+                .ifPresent(savedSession -> connectToDefaultSession(store, savedSession, createConnectionTask, window));
     }
 
-    private static void connectToDefaultSession(final Ds3SessionStore store, final SavedSession savedSession, final CreateConnectionTask createConnectionTask) {
+    private static void connectToDefaultSession(final Ds3SessionStore store, final SavedSession savedSession, final CreateConnectionTask createConnectionTask, final Window window) {
         store.addSession(
                 createConnectionTask.createConnection(
-                        SessionModelService.setSessionModel(savedSession, true)));
+                        SessionModelService.setSessionModel(savedSession, true), window));
     }
 
     public static class SerializedSessionStore {

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/CreateConnectionTask.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/tasks/CreateConnectionTask.java
@@ -25,6 +25,7 @@ import com.spectralogic.dsbrowser.api.services.BuildInfoService;
 import com.spectralogic.dsbrowser.gui.components.newsession.NewSessionModel;
 import com.spectralogic.dsbrowser.gui.services.sessionStore.Session;
 import com.spectralogic.dsbrowser.gui.util.AlertService;
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +52,7 @@ public class CreateConnectionTask {
         this.buildInfoService = buildInfoService;
     }
 
-    public Session createConnection(final NewSessionModel newSessionModel) {
+    public Session createConnection(final NewSessionModel newSessionModel, final Window window) {
         try {
             if (newSessionModel.getProxyServer() != null && newSessionModel.getProxyServer().isEmpty()) {
                 newSessionModel.setProxyServer(null);
@@ -69,32 +70,32 @@ public class CreateConnectionTask {
                     newSessionModel.isUseSSL());
         } catch (final UnknownHostException e) {
             LOG.error("Invalid Endpoint Server Name or IP Address", e);
-            alert.error("invalidEndpointMessage");
+            alert.error("invalidEndpointMessage", window);
         } catch (final FailedRequestUsingMgmtPortException e) {
             LOG.error("Attempted data access on management port -- check endpoint", e);
-            alert.error("checkEndpoint");
+            alert.error("checkEndpoint", window);
         } catch (final FailedRequestException e) {
             if (e.getStatusCode() == 403) {
                 if (e.getError().getCode().equals("RequestTimeTooSkewed")) {
                     LOG.error("Failed To authenticate session : Client's clock is not synchronized with server's clock: ", e);
-                    alert.error("failToAuthenticateMessage");
+                    alert.error("failToAuthenticateMessage", window);
                 } else {
                     LOG.error("Invalid Access ID or Secret Key", e);
-                    alert.error("invalidIDKEYMessage");
+                    alert.error("invalidIDKEYMessage", window);
                 }
             } else if (e.getStatusCode() == 301) {
                 LOG.error("BlackPearl returned an unexpected status code, indicating we are attempting to make a data path request on the Management port", e);
-                alert.error("invalidEndpointMessage");
+                alert.error("invalidEndpointMessage", window);
             } else {
                 LOG.error("BlackPearl returned an unexpected status code", e);
-                alert.error("unexpectedStatusMessage");
+                alert.error("unexpectedStatusMessage", window);
             }
         } catch (final IOException ioe) {
             LOG.error("Encountered a networking error", ioe);
-            alert.error("networkErrorMessage");
+            alert.error("networkErrorMessage", window);
         } catch (final RuntimeException rte) {
             LOG.error("Something went wrong", rte);
-            alert.error("authenticationAlert");
+            alert.error("authenticationAlert", window);
         }
         return null;
     }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/AlertService.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/AlertService.java
@@ -16,12 +16,12 @@
 
 package com.spectralogic.dsbrowser.gui.util;
 
-import com.spectralogic.dsbrowser.gui.components.ds3panel.Ds3Common;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.DialogPane;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -39,21 +39,16 @@ public class AlertService {
     private static final String WARNING_TITLE = "warningTitle";
 
     private final ResourceBundle resourceBundle;
-    private final Ds3Common ds3Common;
-    private Alert alert = null;
 
     @Inject
-    public AlertService(final ResourceBundle resourceBundle, final Ds3Common ds3Common) {
+    public AlertService(final ResourceBundle resourceBundle) {
         this.resourceBundle = resourceBundle;
-        this.ds3Common = ds3Common;
     }
 
 
-    private void showAlertInternal(final String message, final String title, final Alert.AlertType alertType) {
-        if (alert == null) {
-            alert = new Alert(alertType);
-        }
-        alert.initOwner(ds3Common.getWindow());
+    private void showAlertInternal(final String message, final String title, final Alert.AlertType alertType, final Window window) {
+        final Alert alert = new Alert(alertType);
+        alert.initOwner(window);
         alert.setTitle(title);
         alert.setHeaderText(null);
         alert.setAlertType(alertType);
@@ -75,16 +70,16 @@ public class AlertService {
         alert.showAndWait();
     }
 
-    public void error(final String message) {
-        showAlertInternal(resourceBundle.getString(message), resourceBundle.getString(ERROR_TITLE), Alert.AlertType.ERROR);
+    public void error(final String message, final Window window) {
+        showAlertInternal(resourceBundle.getString(message), resourceBundle.getString(ERROR_TITLE), Alert.AlertType.ERROR, window);
     }
 
-    public void info(final String message) {
-        showAlertInternal(resourceBundle.getString(message), resourceBundle.getString(ALERT_TITLE), Alert.AlertType.INFORMATION);
+    public void info(final String message, final Window window) {
+        showAlertInternal(resourceBundle.getString(message), resourceBundle.getString(ALERT_TITLE), Alert.AlertType.INFORMATION, window);
     }
 
-    public void warning(final String message) {
-        showAlertInternal(resourceBundle.getString(message), resourceBundle.getString(WARNING_TITLE), Alert.AlertType.WARNING);
+    public void warning(final String message, final Window window) {
+        showAlertInternal(resourceBundle.getString(message), resourceBundle.getString(WARNING_TITLE), Alert.AlertType.WARNING, window);
     }
 
 }

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/AlertService.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/AlertService.java
@@ -16,6 +16,7 @@
 
 package com.spectralogic.dsbrowser.gui.util;
 
+import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.DialogPane;
@@ -47,8 +48,12 @@ public class AlertService {
 
 
     private void showAlertInternal(final String message, final String title, final Alert.AlertType alertType, final Window window) {
+        Platform.runLater(() -> {
+
         final Alert alert = new Alert(alertType);
-        alert.initOwner(window);
+        if (window != null) {
+            alert.initOwner(window);
+        }
         alert.setTitle(title);
         alert.setHeaderText(null);
         alert.setAlertType(alertType);
@@ -68,6 +73,7 @@ public class AlertService {
         alert.setContentText(message);
         alert.setAlertType(alertType);
         alert.showAndWait();
+        });
     }
 
     public void error(final String message, final Window window) {

--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/Popup.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/util/Popup.java
@@ -15,7 +15,6 @@
 
 package com.spectralogic.dsbrowser.gui.util;
 
-import com.spectralogic.dsbrowser.gui.components.ds3panel.Ds3Common;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
@@ -23,22 +22,11 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 
-import javax.inject.Inject;
-
-
 public class Popup {
 
-    private final Ds3Common ds3Common;
-
-    @Inject
-    public Popup(final Ds3Common ds3Common) {
-        this.ds3Common =  ds3Common;
-    }
-
-    public void show(final Parent parent, final String title, final Boolean resizeable) {
+    public void show(final Parent parent, final String title, final Boolean resizeable, final Window window) {
         final Stage popup = new Stage();
-        popup.initOwner(ds3Common.getWindow());
-
+        popup.initOwner(window);
         popup.initModality(Modality.APPLICATION_MODAL);
         popup.setMaxWidth(1000);
         final Scene popupScene = new Scene(parent);
@@ -50,7 +38,8 @@ public class Popup {
         popup.showAndWait();
     }
 
-    public void show(final Parent parent, final String title) {
-        show(parent, title, false);
+    public void show(final Parent parent, final String title, final Window window) {
+        show(parent, title, false, window);
     }
+
 }

--- a/dsb-gui/src/test/java/com/spectralogic/dsbrowser/gui/util/PopupTest.java
+++ b/dsb-gui/src/test/java/com/spectralogic/dsbrowser/gui/util/PopupTest.java
@@ -19,21 +19,23 @@ import com.spectralogic.dsbrowser.gui.components.about.AboutView;
 import com.spectralogic.dsbrowser.gui.components.ds3panel.Ds3Common;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 
 public class PopupTest {
-    private final static Popup popup = new Popup(new Ds3Common());
+    private final static Popup popup = new Popup();
 
     @Test
     public void show() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         new JFXPanel();
         Platform.runLater(() -> {
-            popup.show(new AboutView().getView(), "About");
+            popup.show(new AboutView().getView(), "About", Mockito.mock(Window.class));
         });
         latch.await(10, TimeUnit.SECONDS);
     }

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/BucketUtilTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/BucketUtilTest.java
@@ -36,6 +36,7 @@ import com.spectralogic.dsbrowser.gui.util.*;
 import com.spectralogic.dsbrowser.util.GuavaCollectors;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import javafx.scene.layout.HBox;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -65,8 +66,9 @@ public class BucketUtilTest {
     private static TempStorageIds envStorageIds;
     private static UUID envDataPolicyId;
     private static final DateTimeUtils DTU = new DateTimeUtils(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @BeforeClass
     public static void setUp() throws IOException {
@@ -82,7 +84,7 @@ public class BucketUtilTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
             try {
                 envDataPolicyId = IntegrationHelpers.setupDataPolicy(TEST_ENV_NAME, false, ChecksumType.Type.MD5, client);
                 envStorageIds = IntegrationHelpers.setup(TEST_ENV_NAME, envDataPolicyId, client);

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/CheckNetwork_Test.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/CheckNetwork_Test.java
@@ -29,14 +29,17 @@ import com.spectralogic.dsbrowser.gui.util.ConfigProperties;
 import com.spectralogic.dsbrowser.gui.util.AlertService;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -47,8 +50,9 @@ public class CheckNetwork_Test {
     private final static ResourceBundle resourceBundle = ResourceBundle.getBundle("lang", new Locale(ConfigProperties.getInstance().getLanguage()));
     private static final Ds3Client client = Ds3ClientBuilder.fromEnv().withHttps(false).build();
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @BeforeClass
     public static void setConnection() {
@@ -64,7 +68,7 @@ public class CheckNetwork_Test {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
         });
     }
 

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/CloseConfirmationHandlerTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/CloseConfirmationHandlerTest.java
@@ -41,6 +41,7 @@ import com.spectralogic.dsbrowser.gui.util.*;
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -66,8 +67,9 @@ public class CloseConfirmationHandlerTest {
     private final static ResourceBundle resourceBundle = ResourceBundle.getBundle("lang", new Locale(ConfigProperties.getInstance().getLanguage()));
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
     private static Path path;
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @BeforeClass
     public static void setConnection() {
@@ -81,7 +83,7 @@ public class CloseConfirmationHandlerTest {
                     new SavedCredentials(client.getConnectionDetails().getCredentials().getClientId(), client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
             handler = new CloseConfirmationHandler(resourceBundle, jobWorkers, Mockito.mock(ShutdownService.class), new Ds3Alert(new Ds3Common()));
             try {
                 path = ResourceUtils.loadFileResource("files/");
@@ -120,7 +122,7 @@ public class CloseConfirmationHandlerTest {
                 newSessionModel.setSecretKey(client.getConnectionDetails().getCredentials().getKey());
                 newSessionModel.setProxyServer(null);
                 final SavedSessionStore savedSessionStorePrevious = SavedSessionStore.loadSavedSessionStore();
-                savedSessionStorePrevious.addSession(createConnectionTask.createConnection(newSessionModel));
+                savedSessionStorePrevious.addSession(createConnectionTask.createConnection(newSessionModel, window));
                 handler.saveSessionStore(savedSessionStorePrevious);
 
                 //To get list of saved session

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/NewSessionModelValidationTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/NewSessionModelValidationTest.java
@@ -15,12 +15,13 @@
 
 package com.spectralogic.dsbrowser.integration;
 
-import com.spectralogic.dsbrowser.gui.components.ds3panel.Ds3Common;
 import com.spectralogic.dsbrowser.gui.components.newsession.NewSessionModel;
 import com.spectralogic.dsbrowser.gui.services.newSessionService.NewSessionModelValidation;
 import com.spectralogic.dsbrowser.gui.util.ConfigProperties;
 import com.spectralogic.dsbrowser.gui.util.AlertService;
+import javafx.stage.Window;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -40,7 +41,7 @@ public class NewSessionModelValidationTest {
         model.setAccessKey("testAccessId");
         model.setSecretKey("testSecretKey");
         model.setDefaultSession(true);
-        assertTrue(new NewSessionModelValidation(new AlertService(resourceBundle, new Ds3Common())).validationNewSession(model));
+        assertTrue(new NewSessionModelValidation(new AlertService(resourceBundle)).validationNewSession(model, Mockito.mock(Window.class)));
     }
 
 }

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/ParseJobInterruptionMapTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/ParseJobInterruptionMapTest.java
@@ -35,9 +35,11 @@ import com.spectralogic.dsbrowser.gui.util.ParseJobInterruptionMap;
 import com.spectralogic.dsbrowser.gui.util.StringConstants;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.controlsfx.control.TaskProgressView;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +69,7 @@ public class ParseJobInterruptionMapTest {
     private final static ResourceBundle resourceBundle = ResourceBundle.getBundle("lang", new Locale(ConfigProperties.getInstance().getLanguage()));
     private static final Ds3Client client = Ds3ClientBuilder.fromEnv().withHttps(false).build();
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
-    private static  final AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private static  final AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private static final CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
 
     @BeforeClass
@@ -87,7 +89,7 @@ public class ParseJobInterruptionMapTest {
                                 client.getConnectionDetails().getCredentials().getKey()),
                         false,
                         false);
-                session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+                session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), Mockito.mock(Window.class));
 
                 //Initializing endpoint
                 endpoint = session.getEndpoint() + StringConstants.COLON + session.getPortNo();

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/services/ds3Panel/Ds3PanelServiceTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/services/ds3Panel/Ds3PanelServiceTest.java
@@ -71,7 +71,7 @@ public class Ds3PanelServiceTest {
     private static TempStorageIds envStorageIds;
     private static UUID envDataPolicyId;
     private final RefreshCompleteViewWorker refreshCompleteViewWorker = new RefreshCompleteViewWorker(null, workers, dateTimeUtils, loggingService);
-    private final AlertService alertService = new AlertService(resourceBundle, ds3Common);
+    private final AlertService alertService = new AlertService(resourceBundle);
     private final PhysicalPlacementTask.PhysicalPlacementTaskFactory physicalPlacementTaskFactory = new PhysicalPlacementTask.PhysicalPlacementTaskFactory() {
         @Override
         public PhysicalPlacementTask create(final Ds3TreeTableValue value) {
@@ -85,7 +85,7 @@ public class Ds3PanelServiceTest {
             loggingService,
             refreshCompleteViewWorker,
             new VersionPopup(resourceBundle, ds3Common, alertService),
-            new Popup(ds3Common),
+            new Popup(),
             new PhysicalPlacementPopup(resourceBundle, ds3Common),
             physicalPlacementTaskFactory);
 

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/services/savedSessionStore/SavedSessionStoreTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/services/savedSessionStore/SavedSessionStoreTest.java
@@ -30,8 +30,10 @@ import com.spectralogic.dsbrowser.gui.util.AlertService;
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.reactfx.collection.LiveArrayList;
 
 import java.io.IOException;
@@ -50,8 +52,9 @@ public class SavedSessionStoreTest {
     private static final Ds3Client client = Ds3ClientBuilder.fromEnv().withHttps(false).build();
     final private static String testSessionName = "SavedSesionsToResest";
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -68,7 +71,7 @@ public class SavedSessionStoreTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
             latch.countDown();
         });
         latch.await();
@@ -124,7 +127,7 @@ public class SavedSessionStoreTest {
     @Test
     public void isSessionUpdatedTest() throws IOException {
         final ObservableList<SavedSession> savedSessions = SavedSessionStore.loadSavedSessionStore().getSessions();
-        session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+        session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
         assertFalse(SavedSessionStore.containsSessionName(savedSessions, session.getSessionName()));
     }
 

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/CreateBucketTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/CreateBucketTaskTest.java
@@ -35,10 +35,12 @@ import com.spectralogic.dsbrowser.integration.IntegrationHelpers;
 import com.spectralogic.dsbrowser.integration.TempStorageIds;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -51,6 +53,7 @@ import static org.junit.Assert.assertTrue;
 
 
 public class CreateBucketTaskTest {
+    private final static Window window = Mockito.mock(Window.class);
     private final Workers workers = new Workers();
     private Session session;
     private boolean successFlag = false;
@@ -61,7 +64,7 @@ public class CreateBucketTaskTest {
     private static TempStorageIds envStorageIds;
     private static UUID envDataPolicyId;
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
 
     @BeforeClass
@@ -90,7 +93,7 @@ public class CreateBucketTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
         });
     }
 

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/CreateFolderTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/CreateFolderTaskTest.java
@@ -36,9 +36,11 @@ import com.spectralogic.dsbrowser.integration.IntegrationHelpers;
 import com.spectralogic.dsbrowser.integration.TempStorageIds;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -63,8 +65,10 @@ public class CreateFolderTaskTest {
     private static TempStorageIds envStorageIds;
     private static UUID envDataPolicyId;
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
+
 
     @BeforeClass
     public static void setUp() {
@@ -80,7 +84,7 @@ public class CreateFolderTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
             try {
                 envDataPolicyId = IntegrationHelpers.setupDataPolicy(TEST_ENV_NAME, false, ChecksumType.Type.MD5, client);
                 envStorageIds = IntegrationHelpers.setup(TEST_ENV_NAME, envDataPolicyId, client);

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3CancelSingleJobTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3CancelSingleJobTaskTest.java
@@ -40,6 +40,7 @@ import javafx.embed.swing.JFXPanel;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.shape.Circle;
+import javafx.stage.Window;
 import org.controlsfx.control.TaskProgressView;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -71,8 +72,9 @@ public class Ds3CancelSingleJobTaskTest {
     private final static ResourceBundle resourceBundle = ResourceBundle.getBundle("lang", new Locale(ConfigProperties.getInstance().getLanguage()));
     private static final Ds3Client client = Ds3ClientBuilder.fromEnv().withHttps(false).build();
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @BeforeClass
     public static void setConnection() {
@@ -88,7 +90,7 @@ public class Ds3CancelSingleJobTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
         });
     }
 

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3DeleteBucketTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3DeleteBucketTaskTest.java
@@ -34,10 +34,12 @@ import com.spectralogic.dsbrowser.integration.IntegrationHelpers;
 import com.spectralogic.dsbrowser.integration.TempStorageIds;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -61,8 +63,9 @@ public class Ds3DeleteBucketTaskTest {
     private static TempStorageIds envStorageIds;
     private static UUID envDataPolicyId;
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @BeforeClass
     public static void startup() throws IOException {
@@ -90,7 +93,7 @@ public class Ds3DeleteBucketTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection( SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection( SessionModelService.setSessionModel(savedSession, false), window);
             try {
                 HELPERS.ensureBucketExists(DELETE_BUCKET_TASK_TEST_BUCKET_NAME, envDataPolicyId);
             } catch (final IOException e) {

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3DeleteFilesTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3DeleteFilesTaskTest.java
@@ -41,10 +41,12 @@ import com.spectralogic.dsbrowser.integration.TempStorageIds;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.control.TreeItem;
+import javafx.stage.Window;
 import javafx.scene.layout.HBox;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
@@ -72,8 +74,9 @@ public class Ds3DeleteFilesTaskTest {
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
     private static TempStorageIds envStorageIds;
     private static UUID envDataPolicyId;
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @Before
     public void setUp() {
@@ -89,7 +92,7 @@ public class Ds3DeleteFilesTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
             try {
                 envDataPolicyId = IntegrationHelpers.setupDataPolicy(TEST_ENV_NAME, false, ChecksumType.Type.MD5, client);
                 envStorageIds = IntegrationHelpers.setup(TEST_ENV_NAME, envDataPolicyId, client);

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3DeleteFoldersTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/Ds3DeleteFoldersTaskTest.java
@@ -35,9 +35,11 @@ import com.spectralogic.dsbrowser.integration.IntegrationHelpers;
 import com.spectralogic.dsbrowser.integration.TempStorageIds;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -63,8 +65,9 @@ public class Ds3DeleteFoldersTaskTest {
     private static final String folderName = "testFolder/";
     private static TempStorageIds envStorageIds;
     private static UUID envDataPolicyId;
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @Before
     public void setUp() throws InterruptedException {
@@ -81,7 +84,7 @@ public class Ds3DeleteFoldersTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
             try {
                 envDataPolicyId = IntegrationHelpers.setupDataPolicy(TEST_ENV_NAME, false, ChecksumType.Type.MD5, client);
                 envStorageIds = IntegrationHelpers.setup(TEST_ENV_NAME, envDataPolicyId, client);

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/GetBucketTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/GetBucketTaskTest.java
@@ -37,6 +37,7 @@ import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.control.TreeTableView;
+import javafx.stage.Window;
 import javafx.scene.layout.HBox;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -58,7 +59,8 @@ public class GetBucketTaskTest {
     private final static ResourceBundle resourceBundle = ResourceBundle.getBundle("lang", new Locale(ConfigProperties.getInstance().getLanguage()));
     private final static String bucketName = "TestGetBucketTask";
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
+    private final static Window window = Mockito.mock(Window.class);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
 
     @BeforeClass
@@ -74,7 +76,7 @@ public class GetBucketTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
         });
     }
 

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/GetJobPriorityTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/GetJobPriorityTaskTest.java
@@ -34,8 +34,10 @@ import com.spectralogic.dsbrowser.gui.util.AlertService;
 import com.spectralogic.dsbrowser.gui.util.StringConstants;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
@@ -51,7 +53,7 @@ public class GetJobPriorityTaskTest {
     private static final Ds3Client client = Ds3ClientBuilder.fromEnv().withHttps(false).build();
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
     private static final String TEST_ENV_NAME = "GetJobPriorityTaskTest";
-    private final AlertService alertService = new AlertService(resourceBundle, new Ds3Common());
+    private final AlertService alertService = new AlertService(resourceBundle);
     private final CreateConnectionTask createConnectionTask = new CreateConnectionTask(alertService, resourceBundle, buildInfoService);
 
     @Before
@@ -69,7 +71,7 @@ public class GetJobPriorityTaskTest {
                     false,
                     false);
             session = createConnectionTask.createConnection(
-                    SessionModelService.setSessionModel(savedSession, false));
+                    SessionModelService.setSessionModel(savedSession, false), Mockito.mock(Window.class));
         });
     }
 

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/GetServiceTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/GetServiceTaskTest.java
@@ -41,6 +41,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.control.TreeItem;
+import javafx.stage.Window;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,8 +71,9 @@ public class GetServiceTaskTest {
     private static TempStorageIds envStorageIds;
     private static UUID envDataPolicyId;
     private static final DateTimeUtils DTU = new DateTimeUtils(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @Before
     public void setUp() throws Exception {
@@ -88,7 +90,7 @@ public class GetServiceTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
 
             try {
                 envDataPolicyId = IntegrationHelpers.setupDataPolicy(TEST_ENV_NAME, false, ChecksumType.Type.MD5, client);

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/ModifyJobPriorityTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/ModifyJobPriorityTaskTest.java
@@ -37,8 +37,10 @@ import com.spectralogic.dsbrowser.gui.util.AlertService;
 import com.spectralogic.dsbrowser.gui.util.StringConstants;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
@@ -53,8 +55,9 @@ public class ModifyJobPriorityTaskTest {
     private static final Ds3Client client = Ds3ClientBuilder.fromEnv().withHttps(false).build();
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
     private static final String TEST_ENV_NAME = "ModifyJobPriorityTaskTest";
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @Before
     public void setUp() throws Exception {
@@ -70,8 +73,9 @@ public class ModifyJobPriorityTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
         });
+
     }
 
     @Test

--- a/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/SearchJobTaskTest.java
+++ b/dsb-integration/src/test/java/com/spectralogic/dsbrowser/integration/tasks/SearchJobTaskTest.java
@@ -35,6 +35,7 @@ import com.spectralogic.dsbrowser.gui.util.DateTimeUtils;
 import com.spectralogic.dsbrowser.gui.util.AlertService;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
+import javafx.stage.Window;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -57,8 +58,9 @@ public class SearchJobTaskTest {
     private static final BuildInfoServiceImpl buildInfoService = new BuildInfoServiceImpl();
     private static final String TEST_ENV_NAME = "DeleteFilesTaskTest";
     private static final DateTimeUtils DTU = new DateTimeUtils(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle, new Ds3Common());
+    private final static AlertService ALERT_SERVICE = new AlertService(resourceBundle);
     private final static CreateConnectionTask createConnectionTask = new CreateConnectionTask(ALERT_SERVICE, resourceBundle, buildInfoService);
+    private final static Window window = Mockito.mock(Window.class);
 
     @Before
     public void setUp() {
@@ -74,7 +76,7 @@ public class SearchJobTaskTest {
                             client.getConnectionDetails().getCredentials().getKey()),
                     false,
                     false);
-            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false));
+            session = createConnectionTask.createConnection(SessionModelService.setSessionModel(savedSession, false), window);
         });
     }
 


### PR DESCRIPTION
This PR fixes popups and parent windows not working in consistently.
Almost all popups are now passed their parent window

The default session can draw a popup before the main window is finished drawing, this is a race condition so we default to allowing the default session to draw that popup without a parent if the parent has not loaded yet.

The new session tab could draw a new session window that caused the sessions tab to not load correctly. (Button on top of table cells)