### PR TITLE
Fixed message in when transferring to path

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/jobService/util/Stats.kt
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/services/jobService/util/Stats.kt
@@ -39,12 +39,13 @@ class Stats(val message: StringProperty, val loggingService: LoggingService, val
         } else {
             toPath
         }
+        val displayName = name.substring((name.lastIndexOf('/') + 1))
         val elapsedSeconds = Instant.now().epochSecond - startTime.epochSecond
         val transferRate = estimateTransferRate(sent, elapsedSeconds)
         val timeRemaining: Float = estimateTimeRemaning(transferRate, total)
         message.set(StringBuilderUtil.getTransferRateString(transferRate.toLong(), timeRemaining.toLong(), (sent.get()),
                 totalMessage, name, location).toString())
-        if (finished) {loggingService.logMessage(StringBuilderUtil.objectSuccessfullyTransferredString(name, displayPath, dateTimeUtils.nowAsString(), location).toString(), LogType.SUCCESS)}
+        if (finished) {loggingService.logMessage(StringBuilderUtil.objectSuccessfullyTransferredString(displayName, displayPath, dateTimeUtils.nowAsString(), location).toString(), LogType.SUCCESS)}
     }
 
     private fun estimateTransferRate(sent: LongProperty, elapsedSeconds: Long) =


### PR DESCRIPTION
We had an issue where confusing data was ending up in the display name of transferred files.