### PR TITLE
Removed trigger for no tabs to show tab popup

### DIFF
--- a/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
+++ b/dsb-gui/src/main/java/com/spectralogic/dsbrowser/gui/components/ds3panel/Ds3PanelPresenter.java
@@ -246,7 +246,6 @@ public class Ds3PanelPresenter implements Initializable {
                 ds3PathIndicator.setText("");
                 ds3PathIndicatorTooltip.setText("");
                 ds3SessionStore.removeSession(ds3Common.getCurrentSession());
-                newSessionDialog();
             }
             try {
                 if (newTab.getContent() instanceof VBox) {


### PR DESCRIPTION
Very small PR. This prevents the new session box from showing at some annoying times.